### PR TITLE
Change 'fireDocumentEvent'

### DIFF
--- a/windows8/cordova.js
+++ b/windows8/cordova.js
@@ -224,13 +224,10 @@ var cordova = {
               documentEventHandlers[type].fire(evt);
             }
             else {
-              setTimeout(function() {
-                  // Fire deviceready on listeners that were registered before cordova.js was loaded.
-                  if (type == 'deviceready') {
-                      document.dispatchEvent(evt);
-                  }
-                  documentEventHandlers[type].fire(evt);
-              }, 0);
+				if (type == 'deviceready') {
+					document.dispatchEvent(evt);
+				}
+				documentEventHandlers[type].fire(evt);
             }
         } else {
             document.dispatchEvent(evt);


### PR DESCRIPTION
In my development environment, if it has "setTimeout", when "suspending" event fired, "pause" event is not called, and when "processed" event fired, "pause" and "resume" will be called at the same time.
