### PR TITLE
device.name fix

### DIFF
--- a/windows8/cordova.js
+++ b/windows8/cordova.js
@@ -4345,6 +4345,7 @@ function Device() {
     this.uuid = null;
     this.cordova = null;
     this.model = null;
+	this.name = null;
 
     var me = this;
 
@@ -4360,6 +4361,7 @@ function Device() {
             me.uuid = info.uuid;
             me.cordova = buildLabel;
             me.model = info.model;
+			me.name = info.name;
             channel.onCordovaInfoReady.fire();
         },function(e) {
             me.available = false;

--- a/windows8/template/www/cordova.js
+++ b/windows8/template/www/cordova.js
@@ -4345,6 +4345,7 @@ function Device() {
     this.uuid = null;
     this.cordova = null;
     this.model = null;
+	this.name = null;
 
     var me = this;
 
@@ -4360,6 +4361,7 @@ function Device() {
             me.uuid = info.uuid;
             me.cordova = buildLabel;
             me.model = info.model;
+			me.name = info.name;
             channel.onCordovaInfoReady.fire();
         },function(e) {
             me.available = false;


### PR DESCRIPTION
device.name wasn't working in the 2.8 branch for Windows 8, it was coming back as "undefined".  This fixes device.name so that it returns the Windows device name (hostname).  I see that this feature has been depreciated however Windows can still use this to get the device name.  

device.model is not supported on Windows 8 but is included in cordova.js for Windows 8.  Not sure if this is a mix up.  The documentation probably needs to be updated too.  device.model isn't supported because there isn't a way to access the model of the device using a Windows Store app.
