### PR TITLE
Fix issue using VS 2013 version of MSBuild

### DIFF
--- a/windows8/bin/check_reqs.js
+++ b/windows8/bin/check_reqs.js
@@ -75,11 +75,11 @@ function check_command(cmd, fail_msg) {
  */
 function CheckSystem() {
     var cmd = 'msbuild -version'
-    var fail_msg = 'The command `msbuild` failed. Make sure you have the latest Windows Phone SDKs installed, and the `msbuild.exe` command (inside C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319) is added to your path.'
+    var fail_msg = 'The command `msbuild` failed. Make sure you have the latest Windows 8 SDKs installed, and the `msbuild.exe` command (inside C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319) is added to your path.'
     var output = check_command(cmd, fail_msg);
-    var msversion = output.match(/Microsoft\s\(R\)\s+Build\sEngine\s[a-z]+\s4\.0/i);
+    var msversion = output.match(/Microsoft\s\(R\)\s+Build\sEngine,?\s[a-z]+\s4\.0/i);
     if (!msversion) {
-        Log('Please install the .NET Framwork v4.0.30319 (in the latest windows phone SDK\'s).', true);
+        Log('Please install the .NET Framwork v4.0.30319 (in the latest windows 8 SDK\'s).', true);
         Log('Make sure the "msbuild" command in your path is pointing to  v4.0.30319 of msbuild as well (inside C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319).', true);
         WScript.Quit(1);
     }


### PR DESCRIPTION
On Windows 8.1 using Visual Studio 2013, MSBuild --version is not exactly same as before.

Since, platforms using MSBuild (Windows 8+, Windows Phone) do not work anymore with CLI.
