### PR TITLE
Background color now applied to windows 8 project config during build process.

### DIFF
--- a/windows8/template/cordova/lib/ApplyPlatformConfig.ps1
+++ b/windows8/template/cordova/lib/ApplyPlatformConfig.ps1
@@ -33,11 +33,13 @@ $startPage = $config.widget.content.src
 $manifest.Package.Applications.Application.StartPage = "www/$startpage"
 
 # Add domain whitelist rules
+
 $acls = [string[]]$config.widget.access.origin
 $rules = $manifest.Package.Applications.Application.ApplicationContentUriRules
 $NS = $manifest.DocumentElement.NamespaceURI
 
 # Remove existing rules from manifest
+
 if ($rules) { $manifest.Package.Applications.Application.RemoveChild($rules)}
 
 if ($acls -and ($acls -notcontains "*")) {
@@ -51,6 +53,33 @@ if ($acls -and ($acls -notcontains "*")) {
     }
 }
 
+# Format background color to windows8 format
+
+$configBgColor = [string]$config.widget.preference.value
+$bgColor = ($configBgColor -replace "0x", "") -replace "#", ""
+
+# Double all bytes if color specified as "fff"
+if ($bgColor.Length -eq 3) {
+    $bgColor = $bgColor[0] + $bgColor[0] + $bgColor[1] + $bgColor[1] + $bgColor[2] + $bgColor[2] 
+}
+
+# Parse hex representation to array of color bytes [b, g, r, a]
+$colorBytes = [System.BitConverter]::GetBytes(
+    [int]::Parse($bgColor,
+    [System.Globalization.NumberStyles]::HexNumber))
+
+Add-Type -AssemblyName PresentationCore
+
+# Create new Color object ignoring alpha, because windows 8 doesn't support it
+# see http://msdn.microsoft.com/en-us/library/windows/apps/br211471.aspx
+$color = ([System.Windows.Media.Color]::FromRgb(
+    $colorBytes[2], $colorBytes[1], $colorBytes[0]
+    # FromRGB method add 100% alpha, so we remove it from resulting string
+    ).ToString()) -replace "#FF", "#"
+
+$manifest.Package.Applications.Application.VisualElements.BackgroundColor = [string]$color
+
+# Write modified manifest file
 $xmlWriter = New-Object System.Xml.XmlTextWriter($manifestFile, $null)
 $xmlWriter.Formatting = "Indented"
 $xmlWriter.Indentation = 4


### PR DESCRIPTION
- Added logic to convert hexadecimal color to windows 8 specific format

this replace https://github.com/apache/cordova-cli/pull/167 in cordova-cli
