### PR TITLE
CB-6977 Support chip architecture as an option for run command for Windows and Windows Phone projects

### DIFF
--- a/windows/template/cordova/lib/build.js
+++ b/windows/template/cordova/lib/build.js
@@ -130,7 +130,9 @@ function build_appx(path, buildtype, buildarchs) {
 
     for (var i = 0; i < buildarchs.length; i++) {
 
-        var buildarch = buildarchs[i];
+        var buildarch = buildarchs[i].toLowerCase();
+        // support for "any cpu" specified with or without space
+        buildarch = buildarch !== "anycpu" ? buildarch : "any cpu";
 
         Log("Building Cordova Windows Project:");
         Log("\tConfiguration : " + buildtype);
@@ -165,7 +167,6 @@ function build_appx(path, buildtype, buildarchs) {
                 // msbuild failed
                 WScript.Quit(2);
             }
-            return "Success";
         } catch (err) {
             Log("Build failed: " + err.message, true);
         }


### PR DESCRIPTION
Implementation for [CB-6977](https://issues.apache.org/jira/browse/CB-6977)

Adds support for `--archs` option to `run` command.
