### PR TITLE
CB-7617 partial match support for --target

### DIFF
--- a/windows/template/cordova/lib/package.js
+++ b/windows/template/cordova/lib/package.js
@@ -107,9 +107,13 @@ module.exports.getPackageName = function (platformPath) {
 module.exports.findDevice = function (target) {
     target = target.toLowerCase();
     return module.exports.listDevices().then(function(deviceList) {
-        for (var idx in deviceList){
-            if (deviceList[idx].toLowerCase() == target) {
-                return Q.resolve(idx);
+        // CB-7617 since we use partial match shorter names should go first,
+        // example case is ['Emulator 8.1 WVGA 4 inch 512MB', 'Emulator 8.1 WVGA 4 inch']
+        var sortedList = deviceList.concat().sort(function (l, r) { return l.length > r.length; });
+        for (var idx in sortedList){
+            if (sortedList[idx].toLowerCase().indexOf(target) > -1) {
+                // we should return index based on original list
+                return Q.resolve(deviceList.indexOf(sortedList[idx]));
             }
         }
         return Q.reject('Specified device not found');


### PR DESCRIPTION
This change allows using partial string when specifying target device/emulator via --target param, for example
<code>
cordova run windows --target="WVGA 4 inch 512" -- --phone
</code>

Example device list for Windows is listed below:
Device
Emulator 8.1 WVGA 4 inch 512MB
Emulator 8.1 WVGA 4 inch
Emulator 8.1 WXGA 4.5 inch
Emulator 8.1 720P 4.7 inch
Emulator 8.1 1080P 5.5 inch
Emulator 8.1 1080P 6 inch
