### PR TITLE
Fix for callback invocation with NO_RESULT

### DIFF
--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -61,7 +61,7 @@ module.exports = function (success, fail, service, action, args) {
             onSuccess = function (result, callbackOptions) {
                 callbackOptions = callbackOptions || {};
                 var callbackStatus;
-                if (callbackOptions.status !== null) {
+                if (callbackOptions.status !== null && callbackOptions.status !== undefined) {
                     callbackStatus = callbackOptions.status;
                 }
                 else {
@@ -77,7 +77,7 @@ module.exports = function (success, fail, service, action, args) {
             onError = function (err, callbackOptions) {
                 callbackOptions = callbackOptions || {};
                 var callbackStatus;
-                if (callbackOptions.status !== null) {
+                if (callbackOptions.status !== null && callbackOptions.status !== undefined) {
                     callbackStatus = callbackOptions.status;
                 }
                 else {

--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -60,18 +60,32 @@ module.exports = function (success, fail, service, action, args) {
             // CB-5806 [Windows8] Add keepCallback support to proxy
             onSuccess = function (result, callbackOptions) {
                 callbackOptions = callbackOptions || {};
+                var callbackStatus;
+                if (callbackOptions.status !== null) {
+                    callbackStatus = callbackOptions.status;
+                }
+                else {
+                    callbackStatus = cordova.callbackStatus.OK;
+                }
                 cordova.callbackSuccess(callbackOptions.callbackId || callbackId,
                     {
-                        status: callbackOptions.status || cordova.callbackStatus.OK,
+                        status: callbackStatus,
                         message: result,
                         keepCallback: callbackOptions.keepCallback || false
                     });
             };
             onError = function (err, callbackOptions) {
                 callbackOptions = callbackOptions || {};
+                var callbackStatus;
+                if (callbackOptions.status !== null) {
+                    callbackStatus = callbackOptions.status;
+                }
+                else {
+                    callbackStatus = cordova.callbackStatus.OK;
+                }
                 cordova.callbackError(callbackOptions.callbackId || callbackId,
                     {
-                        status: callbackOptions.status || cordova.callbackStatus.ERROR,
+                        status: callbackStatus,
                         message: err,
                         keepCallback: callbackOptions.keepCallback || false
                     });


### PR DESCRIPTION
Due to the enumeration of cordova.callbackStatus (NO_RESULT = 0 and OK = 1), the logic used for defaulting to cordova.callbackStatus.OK will always default to cordova.callbackStatus.OK when the callbackStatus is set to cordova.callbackStatus.NO_RESULT.

This change addresses this issue by first checking if callbackOptions.status is null and defaulting to cordova.callbackStatus.OK, otherwise it will accept the callbackOptions.status value provided by the user.