### PR TITLE
CB-8856 Fix 'Id' attr is invalid when creating Windows Store submission build

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -77,7 +77,7 @@ module.exports.run = function (argv) {
     ['package.windows.appxmanifest', 'package.windows80.appxmanifest', 'package.phone.appxmanifest'].forEach(function (file) {
         var fileToReplace = path.join(projectPath, file);
         shell.sed('-i', /\$guid1\$/g, guid, fileToReplace);
-        shell.sed('-i', /\$safeprojectname\$/g, packageName, fileToReplace);
+        shell.sed('-i', /\$packagename\$/g, packageName, fileToReplace);
         shell.sed('-i', /\$projectname\$/g, safeAppName, fileToReplace);
     });
 

--- a/template/cordova/lib/package.js
+++ b/template/cordova/lib/package.js
@@ -96,7 +96,7 @@ module.exports.getAppId = function (platformPath) {
 module.exports.getPackageName = function (platformPath) {
     var manifest = path.join(platformPath, 'package.windows.appxmanifest');
     try {
-        return Q.resolve(/Application Id="(.*?)"/gi.exec(fs.readFileSync(manifest, 'utf8'))[1]);
+        return Q.resolve(/Identity Name="(.*?)"/gi.exec(fs.readFileSync(manifest, 'utf8'))[1]);
     } catch (e) {
         return Q.reject('Can\'t read package name from manifest ' + e);
     }

--- a/template/cordova/lib/prepare.js
+++ b/template/cordova/lib/prepare.js
@@ -122,12 +122,7 @@ function applyCoreProperties(config, manifest, manifestPath, xmlnsPrefix) {
     if(!app) {
         throw new Error('Invalid manifest file (no <Application> node): ' + manifestPath);
     }
-    if (pkgName) {
-        // 64 symbols restriction goes from manifest schema definition
-        // http://msdn.microsoft.com/en-us/library/windows/apps/br211415.aspx
-        var appId = pkgName.length <= 64 ? pkgName : pkgName.substr(0, 64);
-        app.attrib.Id = appId;
-    }
+
     app.attrib.StartPage = 'www/' + startPage;
 
     var visualElementsName = './/' + xmlnsPrefix + 'VisualElements'; 

--- a/template/package.phone.appxmanifest
+++ b/template/package.phone.appxmanifest
@@ -18,7 +18,7 @@
        under the License.
 -->
 <Package xmlns="http://schemas.microsoft.com/appx/2010/manifest" xmlns:m2="http://schemas.microsoft.com/appx/2013/manifest" xmlns:m3="http://schemas.microsoft.com/appx/2014/manifest" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest">
-  <Identity Name="$guid1$" Version="1.0.0.0" Publisher="CN=$username$" />
+  <Identity Name="$packagename$" Version="1.0.0.0" Publisher="CN=$username$" />
   <mp:PhoneIdentity PhoneProductId="$guid1$" PhonePublisherId="db093ed5-53b1-45f7-af72-751e8f36ab80" />
   <Properties>
     <DisplayName>$projectname$</DisplayName>
@@ -33,7 +33,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="$safeprojectname$" StartPage="www/index.html">
+    <Application Id="App" StartPage="www/index.html">
       <m3:VisualElements DisplayName="$projectname$"
                          Square150x150Logo="images\Square150x150Logo.png"
                          Square44x44Logo="images\Square44x44Logo.png"

--- a/template/package.windows.appxmanifest
+++ b/template/package.windows.appxmanifest
@@ -18,7 +18,7 @@
        under the License.
 -->
 <Package xmlns="http://schemas.microsoft.com/appx/2010/manifest" xmlns:m2="http://schemas.microsoft.com/appx/2013/manifest">
-  <Identity Name="$guid1$" Version="1.0.0.0" Publisher="CN=$username$" />
+  <Identity Name="$packagename$" Version="1.0.0.0" Publisher="CN=$username$" />
   <Properties>
     <DisplayName>$projectname$</DisplayName>
     <PublisherDisplayName>$username$</PublisherDisplayName>
@@ -32,7 +32,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="$safeprojectname$" StartPage="www/index.html">
+    <Application Id="App" StartPage="www/index.html">
       <m2:VisualElements DisplayName="$projectname$" 
                          Description="CordovaApp"
                          ForegroundText="light"

--- a/template/package.windows80.appxmanifest
+++ b/template/package.windows80.appxmanifest
@@ -18,7 +18,7 @@
        under the License.
 -->
 <Package xmlns="http://schemas.microsoft.com/appx/2010/manifest">
-  <Identity Name="$guid1$" Version="1.0.0.0" Publisher="CN=$username$" />
+  <Identity Name="$packagename$" Version="1.0.0.0" Publisher="CN=$username$" />
   <Properties>
     <DisplayName>$projectname$</DisplayName>
     <PublisherDisplayName>$username$</PublisherDisplayName>
@@ -32,7 +32,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="$safeprojectname$" StartPage="www/index.html">
+    <Application Id="App" StartPage="www/index.html">
       <VisualElements DisplayName="$projectname$" 
                       Logo="images\Square150x150Logo.png" 
                       SmallLogo="images\Square30x30Logo.png"


### PR DESCRIPTION
We should NOT change Application/Id in .appxmanifest according to widget/id (config.xml) as it does not make any sense, but could lead to build failures like in this particular case:

https://issues.apache.org/jira/browse/CB-8856