### PR TITLE
Alt for discussion: CB-8866: add "Mixed Platforms" and "Win32" and CB-8869: Windows Universal without Windows 8.0

### DIFF
--- a/template/CordovaApp.sln
+++ b/template/CordovaApp.sln
@@ -25,8 +25,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CordovaApp", "CordovaApp", 
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "CordovaApp", "CordovaApp.shproj", "{9EBDB27F-D75B-4D8C-B53F-7BE4A1FE89F9}"
 EndProject
-Project("{262852C6-CD72-467D-83FE-5EEB1973A190}") = "CordovaApp.Windows8.0", "CordovaApp.Windows80.jsproj", "{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}"
-EndProject
 Project("{262852C6-CD72-467D-83FE-5EEB1973A190}") = "CordovaApp.Windows", "CordovaApp.Windows.jsproj", "{58950FB6-2F93-4963-B9CD-637F83F3EFBF}"
 EndProject
 Project("{262852C6-CD72-467D-83FE-5EEB1973A190}") = "CordovaApp.Phone", "CordovaApp.Phone.jsproj", "{31B67A35-9503-4213-857E-F44EB42AE549}"
@@ -34,17 +32,20 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		CordovaApp.projitems*{58950fb6-2f93-4963-b9cd-637f83f3efbf}*SharedItemsImports = 5
-		CordovaApp.projitems*{efffab2f-bfc5-4eda-b545-45ef4995f55a}*SharedItemsImports = 5
 		CordovaApp.projitems*{9ebdb27f-d75b-4d8c-b53f-7be4a1fe89f9}*SharedItemsImports = 13
 		CordovaApp.projitems*{31b67a35-9503-4213-857e-f44eb42ae549}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
 		Release|ARM = Release|ARM
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
@@ -55,6 +56,12 @@ Global
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|ARM.ActiveCfg = Debug|ARM
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|ARM.Build.0 = Debug|ARM
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|ARM.Deploy.0 = Debug|ARM
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|Mixed Platforms.Deploy.0 = Debug|x86
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|Win32.ActiveCfg = Debug|x86
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|Win32.Build.0 = Debug|x86
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|Win32.Deploy.0 = Debug|x86
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|x64.ActiveCfg = Debug|x64
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|x64.Build.0 = Debug|x64
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Debug|x64.Deploy.0 = Debug|x64
@@ -67,6 +74,12 @@ Global
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|ARM.ActiveCfg = Release|ARM
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|ARM.Build.0 = Release|ARM
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|ARM.Deploy.0 = Release|ARM
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|Mixed Platforms.Build.0 = Release|x86
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|Mixed Platforms.Deploy.0 = Release|x86
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|Win32.ActiveCfg = Release|x86
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|Win32.Build.0 = Release|x86
+		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|Win32.Deploy.0 = Release|x86
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|x64.ActiveCfg = Release|x64
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|x64.Build.0 = Release|x64
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF}.Release|x64.Deploy.0 = Release|x64
@@ -79,6 +92,12 @@ Global
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|ARM.ActiveCfg = Debug|ARM
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|ARM.Build.0 = Debug|ARM
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|ARM.Deploy.0 = Debug|ARM
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|Mixed Platforms.Deploy.0 = Debug|x86
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|Win32.ActiveCfg = Debug|x86
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|Win32.Build.0 = Debug|x86
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|Win32.Deploy.0 = Debug|x86
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|x64.ActiveCfg = Debug|x64
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|x64.Build.0 = Debug|x64
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Debug|x64.Deploy.0 = Debug|x64
@@ -91,36 +110,18 @@ Global
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|ARM.ActiveCfg = Release|ARM
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|ARM.Build.0 = Release|ARM
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|ARM.Deploy.0 = Release|ARM
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|Mixed Platforms.Build.0 = Release|x86
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|Mixed Platforms.Deploy.0 = Release|x86
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|Win32.ActiveCfg = Release|x86
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|Win32.Build.0 = Release|x86
+		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|Win32.Deploy.0 = Release|x86
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|x64.ActiveCfg = Release|x64
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|x64.Build.0 = Release|x64
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|x64.Deploy.0 = Release|x64
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|x86.ActiveCfg = Release|x86
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|x86.Build.0 = Release|x86
 		{31B67A35-9503-4213-857E-F44EB42AE549}.Release|x86.Deploy.0 = Release|x86
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|ARM.ActiveCfg = Debug|ARM
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|ARM.Build.0 = Debug|ARM
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|ARM.Deploy.0 = Debug|ARM
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|x64.ActiveCfg = Debug|x64
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|x64.Build.0 = Debug|x64
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|x64.Deploy.0 = Debug|x64
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|x86.ActiveCfg = Debug|x86
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|x86.Build.0 = Debug|x86
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Debug|x86.Deploy.0 = Debug|x86
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|Any CPU.Deploy.0 = Release|Any CPU
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|ARM.ActiveCfg = Release|ARM
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|ARM.Build.0 = Release|ARM
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|ARM.Deploy.0 = Release|ARM
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|x64.ActiveCfg = Release|x64
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|x64.Build.0 = Release|x64
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|x64.Deploy.0 = Release|x64
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|x86.ActiveCfg = Release|x86
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|x86.Build.0 = Release|x86
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A}.Release|x86.Deploy.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -129,6 +130,5 @@ Global
 		{9EBDB27F-D75B-4D8C-B53F-7BE4A1FE89F9} = {3A47E08D-7EA5-4F3F-AA6D-1D4A41F26944}
 		{58950FB6-2F93-4963-B9CD-637F83F3EFBF} = {3A47E08D-7EA5-4F3F-AA6D-1D4A41F26944}
 		{31B67A35-9503-4213-857E-F44EB42AE549} = {3A47E08D-7EA5-4F3F-AA6D-1D4A41F26944}
-		{EFFFAB2F-BFC5-4EDA-B545-45EF4995F55A} = {3A47E08D-7EA5-4F3F-AA6D-1D4A41F26944}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR is an alternative to PR #67 and PR #68 for discussion and mutually exclusive to both. It is intended to solve two problems in one shot:
- [CB-8866](https://issues.apache.org/jira/browse/CB-8866): missing "Mixed Platforms" and "Win32" causes problems when installing a plugin such as [Cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage) with C++ component
- [CB8869](https://issues.apache.org/jira/browse/CB-8869): remove Windows 8.0 from Windows Universal target. The Windows 8.0 target is not supported by some newer tools (such as Visual Studio Express 2013) or Windows Universal plugins (such as [Cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage)), and can confuse newer Windows Universal app developers.

If we cannot drop Windows 8.0 right now, then please ignore this PR as well as PR #68.

As I said in #67 and #68, my ICLA for Apache was already accepted for apache/cordova-wp8#72.