### PR TITLE
Reverted change to version which added pascal casing based on CR feedback

### DIFF
--- a/cordova-windows10.md
+++ b/cordova-windows10.md
@@ -11,7 +11,7 @@ app developers and plugin developers need to know about Windows 10 when building
 Adding Windows 10 support to your app is as easy as setting your Windows target platform version to 
 10.0:
 
-    <preference name="WindowsTargetVersion" value="10.0" />
+    <preference name="windows-target-version" value="10.0" />
 
 To develop apps for Windows 10, you require:
 
@@ -71,12 +71,12 @@ manifest, a warning will be displayed.
 
 ### config.xml Preferences ###
 
-#### WindowsTargetVersion, WindowsPhoneTargetVersion ####
+#### windows-target-version, windows-phone-target-version ####
 
-    <preference name="WindowsTargetVersion" value="10.0" />
-    <preference name="WindowsPhoneTargetVersion" value="10.0" />
+    <preference name="windows-target-version" value="10.0" />
+    <preference name="windows-phone-target-version" value="10.0" />
 
-*At least one is required.*
+*The default value is 8.1 for both platforms*
 
 These preferences identify the version of Windows or Windows Phone you would like your app 
 package to target.
@@ -91,8 +91,8 @@ instead)
 **Scenarios**
 
 If you are targeting Windows 8.1 or Windows 10 only, you only need to have a single 
-`WindowsTargetVersion` setting in your config.xml file.  Explicitly setting 
-`WindowsTargetVersion` to specify Windows 10 will push the Phone setting to 10 as well.
+`windows-target-version` setting in your config.xml file.  Explicitly setting 
+`windows-target-version` to specify Windows 10 will push the Phone setting to 10 as well.
 
 #### WindowsDefaultUriPrefix ####
     <preference name="WindowsDefaultUriPrefix" value="ms-appx://|ms-appx-web://" />

--- a/template/cordova/lib/ConfigParser.js
+++ b/template/cordova/lib/ConfigParser.js
@@ -192,8 +192,7 @@ ConfigParser.prototype = {
     },
 
     getWindowsTargetVersion: function() {
-        // PascalCased version is the new official preference name, but retain the old for back-compat
-        var preference = this.getPreference('WindowsTargetVersion') || this.getPreference('windows-target-version');
+        var preference = this.getPreference('windows-target-version');
 
         if (!preference) 
             preference = '8.1'; // default is 8.1.
@@ -206,7 +205,7 @@ ConfigParser.prototype = {
         // 1. Check for an explicit preference.  If the preference is set explicitly, return that, irrespective of whether it is valid
         // 2. Get the Windows baseline version.  If it's equivalent to 8.0, bump it to 8.1.
         // 3. Return the Windows baseline version.
-        var explicitPreference = this.getPreference('WindowsPhoneTargetVersion') || this.getPreference('windows-phone-target-version');
+        var explicitPreference = this.getPreference('windows-phone-target-version');
         if (explicitPreference)
             return explicitPreference;
 


### PR DESCRIPTION
Feedback was negative for the change from windows-target-version to WindowsTargetVersion.  Opportunistically changing it back before it becomes a thing.