### PR TITLE
CB-9073 Fixes build error when path to project contains `&` symbol

### DIFF
--- a/template/cordova/version.bat
+++ b/template/cordova/version.bat
@@ -15,9 +15,9 @@
 :: specific language governing permissions and limitations
 :: under the License
 @ECHO OFF
-SET full_path=%~dp0
-IF EXIST "%full_path%..\VERSION" (
-    type "%full_path%..\VERSION"
+SET full_path="%~dp0"
+IF EXIST %full_path%..\VERSION (
+    type %full_path%..\VERSION
 ) ELSE (
     ECHO.
     ECHO ERROR: Could not find file VERSION in project folder


### PR DESCRIPTION
This fixes [CB-9073](https://issues.apache.org/jira/browse/CB-9073)