### PR TITLE
CB-9235 Adds more checks based on the windows-target-version

### DIFF
--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -68,12 +68,19 @@ var REQUIRED_VERSIONS = {
     }
 };
 
-var config = new ConfigParser(path.join(__dirname, '..', '..', 'config.xml'));
+function getConfig() {
+    try {
+        return new ConfigParser(path.join(__dirname, '..', '..', 'config.xml'));
+    } catch (e) {
+        throw new Error('Can\'t find config.xml file or it is malformed.');
+    }
+}
+
 
 function getMinimalRequiredVersionFor (requirement) {
 
-    var windowsTargetVersion = config.getWindowsTargetVersion();
-    var windowsPhoneTargetVersion = config.getWindowsPhoneTargetVersion();
+    var windowsTargetVersion = getConfig.getWindowsTargetVersion();
+    var windowsPhoneTargetVersion = getConfig.getWindowsPhoneTargetVersion();
     var windowsReqVersion = Version.tryParse(REQUIRED_VERSIONS[windowsTargetVersion][requirement]);
     var phoneReqVersion = Version.tryParse(REQUIRED_VERSIONS[windowsPhoneTargetVersion][requirement]);
 
@@ -259,7 +266,7 @@ var checkOS = function () {
         var requiredOsVersion = getMinimalRequiredVersionFor('os');
         if (actualVersion.gte(requiredOsVersion) ||
             // Special case for Windows 10/Phone 10  targets which can be built on Windows 7 (version 6.1)
-            actualVersion.major === 6 && actualVersion.minor === 1 && config.getWindowsTargetVersion() === '10.0') {
+            actualVersion.major === 6 && actualVersion.minor === 1 && getConfig.getWindowsTargetVersion() === '10.0') {
             return mapWindowsVersionToName(actualVersion);
         }
 

--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -19,15 +19,226 @@
 
 /*jshint node:true*/
 
-var Q     = require('Q');
+var Q     = require('q');
+var os    = require('os');
+var path  = require('path');
+var shell = require('shelljs');
 
-var MSBuildTools;
+var ConfigParser, MSBuildTools, Version, exec;
 try {
+    ConfigParser = require('../../template/cordova/lib/ConfigParser');
     MSBuildTools = require('../../template/cordova/lib/MSBuildTools');
+    exec = require('../../template/cordova/lib/exec');
+    Version = require('../../template/cordova/lib/Version');
 } catch (ex) {
     // If previous import fails, we're probably running this script
     // from installed platform and the module location is different.
+    ConfigParser = require('./ConfigParser');
     MSBuildTools = require('./MSBuildTools');
+    exec = require('./exec');
+    Version = require('./Version');
+}
+
+// The constant for VS2013 Upd2 PackageVersion. See MSDN for
+// reference: https://msdn.microsoft.com/en-us/library/bb164659(v=vs.120).aspx
+var VS2013_UPDATE2_RC = new Version(12, 0, 30324);
+var REQUIRED_VERSIONS = {
+    '8.0': {
+        os: '6.1',
+        msbuild: '11.0',
+        visualstudio: '11.0',
+        windowssdk: '8.0'
+    },
+    '8.1': {
+        os: '6.2',
+        msbuild: '12.0',
+        visualstudio: '12.0',
+        windowssdk: '8.1',
+        phonesdk: '8.1'
+    },
+    '10.0': {
+        os: '6.2',
+        msbuild: '14.0',
+        visualstudio: '14.0',
+        windowssdk: '10.0',
+        phonesdk: '10.0'
+    }
+};
+
+function getMinimalRequiredVersionFor (requirement) {
+    var config = new ConfigParser(path.join(__dirname, '..', '..', 'config.xml'));
+
+    var windowsTargetVersion = config.getWindowsTargetVersion();
+    var windowsPhoneTargetVersion = config.getWindowsPhoneTargetVersion();
+    var windowsReqVersion = Version.tryParse(REQUIRED_VERSIONS[windowsTargetVersion][requirement]);
+    var phoneReqVersion = Version.tryParse(REQUIRED_VERSIONS[windowsPhoneTargetVersion][requirement]);
+
+    // If we're searching for Windows SDK, we're not
+    // interested in Phone's version and and vice versa.
+    if (requirement === 'windowssdk') return windowsReqVersion;
+    if (requirement === 'phonesdk') return phoneReqVersion;
+
+    // If both windowsReqVersion and phoneReqVersion is valid Versions, choose the max one
+    if (windowsReqVersion && phoneReqVersion) {
+        return windowsReqVersion.gt(phoneReqVersion) ?
+            windowsReqVersion :
+            phoneReqVersion;
+    }
+
+    // Otherwise return that one which is defined and valid
+    return windowsReqVersion || phoneReqVersion;
+}
+
+function getHighestAppropriateVersion (versions, requiredVersion) {
+    return versions.map(function (version) {
+        return Version.tryParse(version);
+    })
+    .sort(Version.comparer)
+    .filter(function (toolVersion) {
+        return toolVersion.gte(requiredVersion);
+    })[0];
+}
+
+/**
+ * Return Version object for current Windows version. User 'ver' binary or
+ *   os.release() in case of errors.
+ *
+ * @return  {Version}  Version information for current OS.
+ */
+function getWindowsVersion() {
+    return exec('ver').then(function (output) {
+        var match = /\[Version (.*)\]\s*$/.exec(output);
+        return Version.fromString(match[1]);
+    }).fail(function () {
+        return Version.fromString(os.release());
+    });
+}
+
+/**
+ * Lists all Visual Studio versions insalled. For VS 2013 if it present, alao
+ *   checks if Update 2 is installed.
+ *
+ * @return  {String[]}  List of installed Visual Studio versions.
+ */
+function getInstalledVSVersions() {
+    // Query all keys with Install value equal to 1, then filter out
+    // those, which are not related to VS itself
+    return exec('reg query HKLM\\SOFTWARE\\Microsoft\\DevDiv\\vs\\Servicing /s /v Install /f 1 /d /e /reg:32')
+    .fail(function () { return ''; })
+    .then(function (output) {
+        return output.split('\n')
+        .reduce(function (installedVersions, line) {
+            var match = /(\d+\.\d+)\\(ultimate|professional|premium|community)/.exec(line);
+            if (match && match[1] && installedVersions.indexOf(match[1]) === -1)
+                installedVersions.push(match[1]);
+            return installedVersions;
+        }, []);
+    })
+    .then(function (installedVersions) {
+        // If there is no VS2013 installed, the we have nothing to do
+        if (installedVersions.indexOf('12.0') === -1) return installedVersions;
+
+        // special case for VS 2013. We need to check if VS2013 update 2 is installed
+        return exec('reg query "HKLM\\SOFTWARE\\Microsoft\\Updates\\Microsoft Visual Studio' +
+            ' 2013\\vsupdate_KB2829760" /v PackageVersion /reg:32')
+        .then(function (output) {
+            var updateVer = Version.fromString(/PackageVersion\s+REG_SZ\s+(.*)/i.exec(output)[1]);
+            // if update version is lover than Update2, reject the promise
+            if (VS2013_UPDATE2_RC.gte(updateVer)) return Q.reject();
+            return installedVersions;
+        })
+        .fail(function () {
+            // if we got any errors on previous steps, we're assuming that
+            // required VS update is not installed.
+            installedVersions.splice(installedVersions.indexOf('12.0'));
+            return installedVersions;
+        });
+    });
+}
+
+/**
+ * Gets list of installed Windows SDKs
+ *
+ * @return  {Version[]}  List of installed SDKs' versions
+ */
+function getInstalledWindowsSdks () {
+    var installedSdks = [];
+    return exec('reg query "HKLM\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows" /s /v InstallationFolder /reg:32')
+    .fail(function () { return ''; })
+    .then(function (output) {
+        var re = /\\Microsoft SDKs\\Windows\\v(\d+\.\d+)\s*InstallationFolder\s+REG_SZ\s+(.*)/gim;
+        var match;
+        while ((match = re.exec(output))){
+            var sdkPath = match[2];
+            // Verify that SDKs is really installed by checking SDKManifest file at SDK root
+            if (shell.test('-e', path.join(sdkPath, 'SDKManifest.xml'))) {
+                installedSdks.push(Version.tryParse(match[1]));
+            }
+        }
+    })
+    .thenResolve(installedSdks);
+}
+
+/**
+ * Gets list of installed Windows Phone SDKs. Separately searches for 8.1 Phone
+ *   SDK and Windows 10 SDK, because the latter is needed for both Windows and
+ *   Windows Phone applications.
+ *
+ * @return  {Version[]}  List of installed Phone SDKs' versions.
+ */
+function getInstalledPhoneSdks () {
+    var installedSdks = [];
+    return exec('reg query "HKLM\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows Phone\\v8.1" /v InstallationFolder /reg:32')
+    .fail(function () { return ''; })
+    .then(function (output) {
+        var match = /\\Microsoft SDKs\\Windows Phone\\v(\d+\.\d+)\s*InstallationFolder\s+REG_SZ\s+(.*)/gim.exec(output);
+        if (match && shell.test('-e', path.join(match[2], 'SDKManifest.xml'))) {
+            installedSdks.push(Version.tryParse(match[1]));
+        }
+    })
+    .then(function () {
+        return exec('reg query "HKLM\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\v10.0" /v InstallationFolder /reg:32');
+    })
+    .fail(function () { return ''; })
+    .then(function (output) {
+        var match = /\\Microsoft SDKs\\Windows\\v(\d+\.\d+)\s*InstallationFolder\s+REG_SZ\s+(.*)/gim.exec(output);
+        if (match && shell.test('-e', path.join(match[2], 'SDKManifest.xml'))) {
+            installedSdks.push(Version.tryParse(match[1]));
+        }
+    })
+    .thenResolve(installedSdks);
+}
+
+/**
+ * Shortens version string or Version object by leaving only first two segments
+ *   (major and minor).
+ * @param   {String|Version}  version  The version identifier. Either Version
+ *   object or string that looks like "12.5.6"
+ * @return  {String}          Shortened version, or undefined if provided
+ *   parameter is not a valid version
+ */
+function shortenVersion (version) {
+    return /^(\d+(?:\.\d+)?)/.exec(version.toString())[1];
+}
+
+function mapWindowsVersionToName(version) {
+    var map = {
+        '6.2': 'Windows 8',
+        '6.3': 'Windows 8.1',
+        '10.0': 'Windows 10'
+    };
+    var majorMinor = shortenVersion(version);
+    return map[majorMinor];
+}
+
+function mapVSVersionToName(version) {
+    var map = {
+        '11.0': '2012',
+        '12.0': '2013',
+        '14.0': '2015'
+    };
+    var majorMinor = shortenVersion(version);
+    return map[majorMinor];
 }
 
 /**
@@ -35,11 +246,20 @@ try {
  * @return {Promise} Promise either fullfilled or rejected with error message.
  */
 var checkOS = function () {
-    var platform = process.platform;
-    return (platform === 'win32') ?
-        Q.resolve(platform):
+    if (process.platform !== 'win32') {
         // Build Universal windows apps available for windows platform only, so we reject on others platforms
-        Q.reject('Cordova tooling for Windows requires Windows OS to build project');
+        return Q.reject('Cordova tooling for Windows requires Windows OS to build project');
+    }
+
+    return getWindowsVersion().then(function (actualVersion) {
+        var requiredOsVersion = getMinimalRequiredVersionFor('os');
+        if (requiredOsVersion.gte(actualVersion)) {
+            return Q.reject('Current Windows version doesn\'t support building this project. ' +
+                'Consider upgrading your OS to ' + mapWindowsVersionToName(requiredOsVersion));
+        }
+
+        return mapWindowsVersionToName(actualVersion);
+    });
 };
 
 /**
@@ -48,12 +268,74 @@ var checkOS = function () {
  *                           or rejected with error message.
  */
 var checkMSBuild = function () {
-    return MSBuildTools.findAvailableVersion()
-    .then(function (msbuildTools) {
-        return Q.resolve(msbuildTools.version);
-    }, function () {
-        return Q.reject('MSBuild tools not found. Please install MSBuild tools or VS 2013 from ' +
-            'https://www.visualstudio.com/downloads/download-visual-studio-vs');
+    return MSBuildTools.findAvailableVersions()
+    .then(function (msbuildToolsVersions) {
+        var msbuildRequiredVersion = getMinimalRequiredVersionFor('msbuild');
+        msbuildToolsVersions = msbuildToolsVersions.map(function (msbuildToolsVersion) {
+            return msbuildToolsVersion.version;
+        });
+
+        var appropriateVersion = getHighestAppropriateVersion(msbuildToolsVersions, msbuildRequiredVersion);
+        return appropriateVersion ?
+            shortenVersion(appropriateVersion) :
+            Q.reject('MSBuild tools v.' + shortenVersion(msbuildRequiredVersion) + ' not found. ' +
+                'Please install Visual Studio ' + mapVSVersionToName(getMinimalRequiredVersionFor('visualstudio')) +
+                ' from https://www.visualstudio.com/downloads/download-visual-studio-vs');
+    });
+};
+
+var checkVS = function () {
+    var vsRequiredVersion = getMinimalRequiredVersionFor('visualstudio');
+
+    return getInstalledVSVersions()
+    .then(function (installedVersions) {
+        var appropriateVersion = getHighestAppropriateVersion(installedVersions, vsRequiredVersion);
+        return appropriateVersion ?
+            shortenVersion(appropriateVersion) :
+            Q.reject('Required version of Visual Studio not found. Please install Visual Studio ' +
+                mapVSVersionToName(vsRequiredVersion) +
+                ' from https://www.visualstudio.com/downloads/download-visual-studio-vs');
+    });
+};
+
+var checkWinSdk = function () {
+    return getInstalledWindowsSdks()
+    .then(function (installedSdks) {
+        var requiredVersion = getMinimalRequiredVersionFor('windowssdk');
+        var hasSdkInstalled = installedSdks.some(function (installedSdk) {
+            return installedSdk.eq(requiredVersion);
+        });
+        if (!hasSdkInstalled) {
+            return Q.reject('Windows SDK not found. Please ensure that you have installed ' +
+                'Windows ' + shortenVersion(requiredVersion) + ' SDK along with Visual Studio or install ' +
+                'Windows ' + shortenVersion(requiredVersion) + ' SDK separately from ' +
+                'https://dev.windows.com/en-us/downloads');
+        }
+
+        return shortenVersion(requiredVersion);
+    });
+};
+
+var checkPhoneSdk = function () {
+    var requiredVersion = getMinimalRequiredVersionFor('phonesdk');
+
+    return getInstalledPhoneSdks()
+    .then(function (installedSdks) {
+        var requiredVersion = getMinimalRequiredVersionFor('phonesdk');
+
+        var hasSdkInstalled = installedSdks.some(function (installedSdk) {
+            return installedSdk.eq(requiredVersion);
+        });
+
+        return hasSdkInstalled ?
+            shortenVersion(requiredVersion) :
+            Q.reject();
+    })
+    .fail(function () {
+        return Q.reject('Windows Phone SDK not found. Please ensure that you have installed ' +
+            'Windows Phone ' + shortenVersion(requiredVersion) + ' SDK along with Visual Studio or install ' +
+            'Windows Phone ' + shortenVersion(requiredVersion) + ' SDK separately from ' +
+            'https://dev.windows.com/develop/download-phone-sdk');
     });
 };
 
@@ -80,16 +362,18 @@ var Requirement = function (id, name, isFatal) {
 
 var requirements = [
     new Requirement('os', 'Windows OS', true),
-    new Requirement('msbuild', 'MSBuild Tools')
+    new Requirement('msbuild', 'MSBuild Tools'),
+    new Requirement('visualstudio', 'Visual Studio'),
+    new Requirement('windowssdk', 'Windows SDK'),
+    new Requirement('phonesdk', 'Windows Phone SDK')
 ];
 
 // Define list of checks needs to be performed
-var checkFns = [checkOS, checkMSBuild];
+var checkFns = [checkOS, checkMSBuild, checkVS, checkWinSdk, checkPhoneSdk];
 
 /**
  * Methods that runs all checks one by one and returns a result of checks
- * as an array of Requirement objects. This method intended to be used by cordova-lib check_reqs method
- *
+ * as an array of Requirement objects. This method intended to be used by cordova-lib check_reqs method.
  * @return Promise<Requirement[]> Array of requirements. Due to implementation, promise is always fulfilled.
  */
 module.exports.check_all = function() {

--- a/spec/unit/Version.spec.js
+++ b/spec/unit/Version.spec.js
@@ -52,20 +52,17 @@ describe('Version parse functions work as expected.', function() {
     expect(version.build).toBe(4);
     expect(version.qfe).toBe(7);
 
+    it('should parse incomplete version string.', function() {
+        var version = Version.fromString('1.5.3');
+        expect(version.major).toBe(1);
+        expect(version.minor).toBe(5);
+        expect(version.build).toBe(3);
+        expect(version.qfe).toBe(0);
+    });
+
     it('should produce an error as the version string is invalid', function() {
         try {
             Version.fromString('This is invalid.');
-
-            expect(false).toBe(true);
-        }
-        catch (ex) {
-            expect(ex.constructor).toBe(RangeError);
-        }
-    });
-
-    it('should produce an error as the string is incomplete.', function() {
-        try {
-            Version.fromString('1.5.3');
 
             expect(false).toBe(true);
         }

--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -135,7 +135,6 @@ describe('check_reqs module', function () {
         it('that should not run other requirements checks if `fatal` requirement isn\'t installed', function  (done) {
             check_reqs.__set__('requirements', fakeRequirements);
             // The second requirement is fatal, so we're setting up second check to fail
-            // fakeCheckFns[1] = function () { return Q.reject('Error message'); };
             fakeCheckFns[1] = checkSpy.andReturn(Q.reject('Error message'));
             check_reqs.__set__('checkFns', fakeCheckFns);
 

--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -29,7 +29,8 @@ describe('run method', function() {
         buildRunOriginal,
         getPackageOriginal,
         deployToPhoneOriginal,
-        deployToDesktopOriginal;
+        deployToDesktopOriginal,
+        ranWithElevatedPermissionsOriginal;
 
     var isCordovaProjectFalse = function () {
         return false;
@@ -49,6 +50,8 @@ describe('run method', function() {
         getPackageOriginal = run.__get__('packages.getPackage');
         deployToPhoneOriginal = run.__get__('packages.deployToPhone');
         deployToDesktopOriginal = run.__get__('packages.deployToDesktop');
+        ranWithElevatedPermissionsOriginal = run.__get__('ranWithElevatedPermissions');
+        run.__set__('ranWithElevatedPermissions', function () { return false; });
     });
 
     afterEach(function() {
@@ -58,6 +61,7 @@ describe('run method', function() {
         run.__set__('packages.getPackage', getPackageOriginal);
         run.__set__('packages.deployToPhone', deployToPhoneOriginal);
         run.__set__('packages.deployToDesktop', deployToDesktopOriginal);
+        run.__set__('ranWithElevatedPermissions', ranWithElevatedPermissionsOriginal);
     });
 
     it('spec.1 should not run if not launched from project directory', function(done) {

--- a/template/cordova/lib/MSBuildTools.js
+++ b/template/cordova/lib/MSBuildTools.js
@@ -53,6 +53,18 @@ module.exports.findAvailableVersion = function () {
     });
 };
 
+module.exports.findAvailableVersions = function () {
+    var versions = ['14.0', '12.0', '4.0'];
+
+    return Q.all(versions.map(checkMSBuildVersion))
+    .then(function (toolsVersions) {
+        return toolsVersions
+        .filter(function (tool) {
+            return tool;
+        });
+    });
+};
+
 function checkMSBuildVersion(version) {
     var deferred = Q.defer();
     exec('reg query HKLM\\SOFTWARE\\Microsoft\\MSBuild\\ToolsVersions\\' + version + ' /v MSBuildToolsPath')

--- a/template/cordova/lib/Version.js
+++ b/template/cordova/lib/Version.js
@@ -31,7 +31,7 @@ function zeroIfUndefined(val) {
     return val;
 }
 
-Version.Expression = /^\d{1,8}\.\d{1,8}\.\d{1,8}\.\d{1,8}$/;
+Version.Expression = /^\d{1,8}(\.\d{1,8}){0,3}$/;
 Version.fromString = function(str) {
     var result = Version.tryParse(str);
     if (!result)

--- a/template/cordova/lib/run.js
+++ b/template/cordova/lib/run.js
@@ -32,12 +32,10 @@ module.exports.run = function (argv) {
         return Q.reject('Could not find project at ' + ROOT);
     }
 
-    try {
-        // Check if ran from admin prompt and fail quickly if CLI has administrative permissions
-        // http://stackoverflow.com/a/11995662/64949
-        execSync('net session', {'stdio': 'ignore'});
+    // Check if ran from admin prompt and fail quickly if CLI has administrative permissions
+    // http://stackoverflow.com/a/11995662/64949
+    if (ranWithElevatedPermissions())
         return Q.reject('Can not run this platform with administrative permissions. Please run from a non-admin prompt.');
-    } catch (e) {}
 
     // parse arg
     var args  = nopt({'debug': Boolean, 'release': Boolean, 'nobuild': Boolean,
@@ -144,4 +142,21 @@ module.exports.help = function () {
 function projFileToType(projFile) 
 {
     return projFile.replace(/CordovaApp|jsproj|\./gi, '').toLowerCase();
+}
+
+/**
+ * Checks if current process is an with administrative permissions (e.g. from
+ *   elevated command prompt).
+ *
+ * @return  {Boolean}  true if elevated permissions detected, otherwise false
+ */
+function ranWithElevatedPermissions () {
+    try {
+        // Check if ran from admin prompt and fail quickly if CLI has administrative permissions
+        // http://stackoverflow.com/a/11995662/64949
+        execSync('net session', {'stdio': 'ignore'});
+        return true;
+    } catch (e) {
+        return false;
+    }
 }


### PR DESCRIPTION
This is an implementation for [CB-9235](https://issues.apache.org/jira/browse/CB-9235)

The logic of `check_all` method was updated to include additional checks for Visual Studio and  Windows/Windows phone SDKs.
Also logic of checks has been improved to checks for versions depending on the `windows-target-version` and `windows-phone-target-version` preferences from platform’s config.xml.
