### PR TITLE
CB-9271: Removed the unnecessary device capabilities from the Windows 10

### DIFF
--- a/template/package.windows10.appxmanifest
+++ b/template/package.windows10.appxmanifest
@@ -68,16 +68,6 @@
 
   <Capabilities>
     <Capability Name="internetClient" />
-	
-	<!-- Windows 10 Technical Preview 2 has a bug in which enumerating 
-	     devices fails if you don't have the capability for those devices.
-		 This bug causes a fast-fail (no JavaScript handling of the error).
-		 An implementation detail of the Web Platform accessors of hardware
-		 causes these to be aggressively enumerated, therefore, we ask
-		 for the device capabilities up front.  This will be removed in a 
-		 later version of cordova-windows. -->
-	<DeviceCapability Name="webcam" />
-	<DeviceCapability Name="microphone" />
   </Capabilities>
 
 </Package>


### PR DESCRIPTION
Removed the unnecessary device capabilities from the Windows 10 app manifest.  These capabilities are no longer required as they no longer cause a crash in later flights of the OS.