### PR TITLE
CB-9283: Add support for Windows 10 WinAppDeployCmd

### DIFF
--- a/spec/unit/deployment.spec.js
+++ b/spec/unit/deployment.spec.js
@@ -1,0 +1,282 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var rewire     = require('rewire'),
+    deployment = rewire('../../template/cordova/lib/deployment'),
+    run        = deployment.__get__('run'),
+    Q          = require('q'),
+
+    AppDeployCmdTool = deployment.__get__('AppDeployCmdTool'),
+    WinAppDeployCmdTool = deployment.__get__('WinAppDeployCmdTool');
+
+var TEST_APP_PACKAGE_NAME = '"c:\\testapppackage.appx"',
+    TEST_APP_PACKAGE_ID   = '12121212-3434-3434-3434-567856785678';
+
+describe('The correct version of the app deployment tool is obtained.', function() {
+
+    it('Provides an AppDeployCmdTool when 8.1 is requested.', function() {
+
+        var tool = deployment.getDeploymentTool('8.1');
+        expect(tool instanceof AppDeployCmdTool).toBe(true);
+
+    });
+
+    it('Provides a WinAppDeployCmdTool when 10.0 is requested.', function() {
+
+        var tool = deployment.getDeploymentTool('10.0');
+        expect(tool instanceof WinAppDeployCmdTool).toBe(true);
+
+    });
+
+});
+
+describe('Windows 10 deployment interacts with the file system as expected.', function() {
+
+    function runMock(cmd, args, cwd) {
+        expect(cmd).toBe('c:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\WinAppDeployCmd.exe');
+        switch (args[0]) {
+            case 'devices':
+                var output = 'Windows App Deployment Tool\r\nVersion 10.0.0.0\r\nCopyright (c) Microsoft Corporation. All rights reserved.\r\n\r\nDiscovering devices...\r\nIP Address      GUID                                    Model/Name\r\n127.0.0.1   00000015-b21e-0da9-0000-000000000000    Lumia 1520 (RM-940)\r\n10.120.70.172   00000000-0000-0000-0000-00155d619532    00155D619532\r\n10.120.68.150   00000000-0000-0000-0000-00155d011765    00155D011765\r\nDone.';
+                return Q(output);
+
+            case 'update':
+            case 'install':
+                expect(args[2]).toBe(TEST_APP_PACKAGE_NAME);
+                expect(args[4]).toBe('127.0.0.1');
+                return Q('');
+
+            case 'uninstall':
+                expect(args[2]).toBe(TEST_APP_PACKAGE_ID);
+                expect(args[4]).toBe('10.120.68.150');
+                return Q('');
+
+        }
+    }
+
+    var mockedProgramFiles = process.env['ProgramFiles(x86)'];
+    beforeEach(function() {
+        deployment.__set__('run', runMock);    
+        process.env['ProgramFiles(x86)'] = 'c:\\Program Files (x86)';
+    });
+    afterEach(function() {
+        deployment.__set__('run', run);
+        if (mockedProgramFiles) {
+            process.env['ProgramFiles(x86)'] = mockedProgramFiles;
+        } else {
+            delete process.env['ProgramFiles(x86)'];
+        }
+    });
+
+    it('enumerateDevices returns a valid set of objects', function() {
+        var deploymentTool = deployment.getDeploymentTool('10.0');
+        var done = false;
+        deploymentTool.enumerateDevices().then(function(deviceList) {
+
+            expect(deviceList.length).toBe(3);
+            expect(deviceList[0].name).toBe('Lumia 1520 (RM-940)');
+            expect(deviceList[0].index).toBe(0);
+            expect(deviceList[0].type).toBe('device');
+            
+            done = true;
+
+        });
+
+        waitsFor(function() { return done; });
+    });
+
+    it('installAppPackage passes the correct set of parameters', function() {
+        var deploymentTool = deployment.getDeploymentTool('10.0');
+        var done = false;
+        deploymentTool.enumerateDevices().then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ false).then(function() {
+
+                // expect() calls are in the runMock function
+                done = true;
+
+            });
+        });
+
+        waitsFor(function() { return done; });
+    });
+
+    it('installAppPackage passes the correct set of parameters when updating', function() {
+        var deploymentTool = deployment.getDeploymentTool('10.0');
+        var done = false;
+        deploymentTool.enumerateDevices().then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ true).then(function() {
+
+                // expect() calls are in the runMock function
+                done = true;
+
+            });
+        });
+
+        waitsFor(function() { return done; });
+    });
+
+    it('uninstallAppPackage passes the correct set of parameters', function() {
+        var deploymentTool = deployment.getDeploymentTool('10.0');
+        var done = false;
+        deploymentTool.enumerateDevices().then(function(deviceList) {
+            deploymentTool.uninstallAppPackage(TEST_APP_PACKAGE_ID, deviceList[2]).then(function() {
+
+                // expect() calls are in the runMock function
+                done = true;
+
+            });
+        });
+
+        waitsFor(function() { return done; });
+    });
+
+});
+
+describe('Windows 8.1 deployment interacts with the file system as expected.', function() {
+
+    function runMock(cmd, args, cwd) {
+        expect(cmd).toBe('c:\\Program Files (x86)\\Microsoft SDKs\\Windows Phone\\v8.1\\Tools\\AppDeploy\\AppDeployCmd.exe');
+        switch (args[0]) {
+            case '/EnumerateDevices':
+                var output = '\r\nDevice Index    Device Name\r\n------------    -------------------------------\r\n 0              Device\r\n 1              Mobile Emulator 10.0.10150.0 WVGA 4 inch 512MB\r\n 2              Mobile Emulator 10.0.10150.0 WVGA 4 inch 1GB\r\n 3              Mobile Emulator 10.0.10150.0 WXGA 4.5 inch 1GB\r\n 4              Mobile Emulator 10.0.10150.0 720p 5 inch 1GB\r\n 5              Mobile Emulator 10.0.10150.0 1080p 6 inch 2GB\r\n 6              Emulator 8.1 WVGA 4 inch 512MB\r\n 7              Emulator 8.1 WVGA 4 inch\r\n 8              Emulator 8.1 WXGA 4.5 inch\r\n 9              Emulator 8.1 720P 4.7 inch\r\n 10             Emulator 8.1 1080P 5.5 inch\r\n 11             Emulator 8.1 1080P 6 inch\r\nDone.\r\n';
+                return Q(output);
+
+            case '/update':
+            case '/install':
+            case '/updatelaunch':
+            case '/installlaunch':
+                expect(args[1]).toBe(TEST_APP_PACKAGE_NAME);
+                expect(args[2]).toBe('/targetdevice:de');
+                return Q('');
+
+            case '/uninstall':
+                expect(args[1]).toBe(TEST_APP_PACKAGE_ID);
+                expect(args[2]).toBe('/targetdevice:5');
+                return Q('');
+
+            default:
+                throw new Error('Unrecognized AppDeployCmd parameter "' + args[0] + '"');
+
+        }
+    }
+
+    var mockedProgramFiles = process.env['ProgramFiles(x86)'];
+    beforeEach(function() {
+        deployment.__set__('run', runMock);    
+        process.env['ProgramFiles(x86)'] = 'c:\\Program Files (x86)';
+    });
+    afterEach(function() {
+        deployment.__set__('run', run);
+        if (mockedProgramFiles) {
+            process.env['ProgramFiles(x86)'] = mockedProgramFiles;
+        } else {
+            delete process.env['ProgramFiles(x86)'];
+        }
+    });
+
+    it('enumerateDevices returns a valid set of objects', function() {
+        var deploymentTool = deployment.getDeploymentTool('8.1');
+        var done = false;
+        deploymentTool.enumerateDevices().then(function(deviceList) {
+
+            expect(deviceList.length).toBe(12);
+            expect(deviceList[0].name).toBe('Device');
+            expect(deviceList[0].index).toBe(0);
+            expect(deviceList[0].type).toBe('device');
+
+            expect(deviceList[5].name).toBe('Mobile Emulator 10.0.10150.0 1080p 6 inch 2GB');
+            expect(deviceList[5].index).toBe(5);
+            expect(deviceList[5].type).toBe('emulator');
+
+            done = true;
+
+        });
+        waitsFor(function() { return done; });
+    });
+
+    it('installAppPackage passes the correct set of parameters', function() {
+        var deploymentTool = deployment.getDeploymentTool('8.1');
+        var done = false;
+        deploymentTool.enumerateDevices().then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ false).then(function() {
+
+                // expect() calls are in the runMock function
+                done = true;
+
+            });
+        });
+        waitsFor(function() { return done; });
+    });
+
+    it('installAppPackage passes the correct set of parameters when updating', function() {
+        var deploymentTool = deployment.getDeploymentTool('8.1');
+        var done = false;
+        deploymentTool.enumerateDevices().then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ true).then(function() {
+
+                // expect() calls are in the runMock function
+                done = true;
+
+            });
+        });
+        waitsFor(function() { return done; });
+    });
+
+    it('installAppPackage passes the correct set of parameters when launching', function() {
+        var deploymentTool = deployment.getDeploymentTool('8.1');
+        var done = false;
+        deploymentTool.enumerateDevices().then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ true, /*shouldUpdate*/ false).then(function() {
+
+                // expect() calls are in the runMock function
+                done = true;
+
+            });
+        });
+        waitsFor(function() { return done; });
+    });
+
+    it('installAppPackage passes the correct set of parameters when updating and launching', function() {
+        var deploymentTool = deployment.getDeploymentTool('8.1');
+        var done = false;
+        deploymentTool.enumerateDevices().then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ true, /*shouldUpdate*/ true).then(function() {
+
+                // expect() calls are in the runMock function
+                done = true;
+
+            });
+        });
+        waitsFor(function() { return done; });
+    });
+
+    it('uninstallAppPackage passes the correct set of parameters', function() {
+        var deploymentTool = deployment.getDeploymentTool('8.1');
+        var done = false;
+        deploymentTool.enumerateDevices().then(function(deviceList) {
+            deploymentTool.uninstallAppPackage(TEST_APP_PACKAGE_ID, deviceList[5]).then(function() {
+
+                // expect() calls are in the runMock function
+                done = true;
+
+            });
+        });
+        waitsFor(function() { return done; });
+    });
+
+});

--- a/template/cordova/lib/deployment.js
+++ b/template/cordova/lib/deployment.js
@@ -1,0 +1,283 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+var Q     = require('q'),
+    fs    = require('fs'),
+    /* jshint ignore:start */ // 'path' only used in ignored blocks
+    path  = require('path'),
+    /* jshint ignore:end */
+    proc  = require('child_process');
+
+// neither 'exec' nor 'spawn' was sufficient because we need to pass arguments via spawn
+// but also need to be able to capture stdout / stderr
+function run(cmd, args, opt_cwd) {
+    var d = Q.defer();
+    try {
+        var child = proc.spawn(cmd, args, {cwd: opt_cwd, maxBuffer: 1024000});
+        var stdout = '', stderr = '';
+        child.stdout.on('data', function(s) { stdout += s; });
+        child.stderr.on('data', function(s) { stderr += s; });
+        child.on('exit', function(code) {
+            if (code) {
+                d.reject(stderr);
+            } else {
+                d.resolve(stdout);
+            }
+        });
+    } catch(e) {
+        console.error('error caught: ' + e);
+        d.reject(e);
+    }
+    return d.promise;
+}
+
+function DeploymentTool() {
+
+}
+
+/**
+ * Determines whether the requested version of the deployment tool is available.
+ * @returns True if the deployment tool can function; false if not.
+ */
+DeploymentTool.prototype.isAvailable = function() {
+    return fs.existsSync(this.path);
+};
+
+/**
+ * Enumerates devices attached to the development machine.
+ * @returns A Promise for an array of objects, which should be passed into other functions to represent the device.
+ * @remarks The returned objects contain 'index', 'name', and 'type' properties indicating basic information about them, 
+ *    which is limited to the information provided by the system.  Other properties may also be included, but they are 
+ *    specific to the deployment tool which created them and are likely used internally.
+ */
+DeploymentTool.prototype.enumerateDevices = function() {
+    return Q.reject('May not use DeploymentTool directly, instead get an instance from DeploymentTool.getDeploymentTool()');
+};
+
+/**
+ * Installs an app package to the target device.
+ * @returns A Promise which will be fulfilled on success or rejected on failure.
+ * @param pathToAppxPackage The path to the .appx package to install.
+ * @param targetDevice An object returned from a successful call to enumerateDevices.
+ * @shouldLaunch Indicates whether to launch the app after installing it.
+ * @shouldUpdate Indicates whether to explicitly update the app, or install clean.
+ * @pin Optionally provided if the device requires pairing for deployment.
+ */
+DeploymentTool.prototype.installAppPackage = function(pathToAppxPackage, targetDevice, shouldLaunch, shouldUpdate, pin) {
+    return Q.reject('May not use DeploymentTool directly, instead get an instance from DeploymentTool.getDeploymentTool()');
+};
+
+/**
+ * Uninstalls an app package from the target device.
+ * @returns A Promise which will be fulfilled on success or rejected on failure.
+ * @param packageInfo The app package name or Phone GUID representing the app.
+ * @param targetDevice An object returned from a successful call to enumerateDevices.
+ */
+DeploymentTool.prototype.uninstallAppPackage = function(packageInfo, targetDevice) {
+    return Q.reject('Unable to uninstall any app packages because that feature is not supported.');
+};
+
+/**
+ * Gets a list of installed apps on the target device.  This function is not supported for
+ * Windows Phone 8.1.
+ * @param targetDevice {Object} An object returned from a successful call to enumerateDevices.
+ * @returns A Promise for an array of app names.
+ */
+DeploymentTool.prototype.getInstalledApps = function(targetDevice) {
+    return Q.reject('Unable to get installed apps because that feature is not supported.');
+};
+
+/**
+ * Launches an app on the target device.  This function is not supported for Windows 10.
+ * @param packageInfo {String} The app package name or Phone GUID representing the app.
+ * @param targetDevice {Object} An object returned from a successful call to enumerateDevices.
+ * @returns A Promise for when the app is launched.
+ */
+DeploymentTool.prototype.launchApp = function(packageInfo, targetDevice) {
+    return Q.reject('Unable to launch an app because that feature is not supported.');
+};
+
+/**
+ * Gets a DeploymentTool to deploy to devices or emulators.
+ * @param targetOsVersion {String} The version of the 
+ */
+DeploymentTool.getDeploymentTool = function(targetOsVersion) {
+    if (targetOsVersion === '8.1') {
+        return new AppDeployCmdTool(targetOsVersion);
+    }
+    else {
+        return new WinAppDeployCmdTool(targetOsVersion);
+    }
+};
+
+// DeviceInfo is an opaque object passed to install/uninstall.
+// Implementations of DeploymentTool can populate it with any additional
+//  information required for accessing them.
+function DeviceInfo(deviceIndex, deviceName, deviceType) {
+    this.index = deviceIndex;
+    this.name = deviceName;
+    this.type = deviceType;
+}
+
+DeviceInfo.prototype.toString = function() {
+    return this.index + '. ' + this.name + ' (' + this.type + ')';
+};
+
+function AppDeployCmdTool(targetOsVersion) {
+    if (!(this instanceof AppDeployCmdTool))
+        throw new ReferenceError('Only create an AppDeployCmdTool as an instance object.');
+
+    DeploymentTool.call(this);
+    this.targetOsVersion = targetOsVersion;
+
+    /* jshint ignore:start */ /* Ignore jshint to use dot notation for 2nd process.env access for consistency */
+    var programFilesPath = process.env['ProgramFiles(x86)'] || process.env['ProgramFiles'];
+    this.path = path.join(programFilesPath, 'Microsoft SDKs', 'Windows Phone', 'v' + this.targetOsVersion, 'Tools', 'AppDeploy', 'AppDeployCmd.exe');
+    /* jshint ignore:end */
+}
+
+AppDeployCmdTool.prototype = Object.create(DeploymentTool.prototype);
+AppDeployCmdTool.prototype.constructor = AppDeployCmdTool;
+
+AppDeployCmdTool.prototype.enumerateDevices = function() {
+    var that = this;
+    //  9              Emulator 8.1 720P 4.7 inch\r\n
+    //    maps to
+    // [(line), 9, 'Emulator 8.1 720P 4.7 inch']
+    // Expansion is: space, index, spaces, name
+    var LINE_TEST = /^\s(\d+?)\s+(.+?)$/m;
+    return run(that.path, ['/EnumerateDevices']).then(function(result) {
+        var lines = result.split('\n');
+        var matchedLines = lines.filter(function(line) {
+            return LINE_TEST.test(line);
+        });
+
+        var devices = matchedLines.map(function(line, arrayIndex) {
+            var match = line.match(LINE_TEST);
+            var index = parseInt(match[1], 10);
+            var name = match[2];
+
+            var shorthand = '';
+            var type = 'emulator';
+
+            if (name === 'Device') {
+                shorthand = 'de';
+                type = 'device';
+            } else if (arrayIndex === 1) {
+                shorthand = 'xd';
+            } else {
+                shorthand = index;
+            }
+            var deviceInfo = new DeviceInfo(index, name, type);
+            deviceInfo.__sourceLine = line;
+            deviceInfo.__shorthand = shorthand;
+            return deviceInfo;
+        });
+
+        return devices;
+    });
+};
+
+AppDeployCmdTool.prototype.installAppPackage = function(pathToAppxPackage, targetDevice, shouldLaunch, shouldUpdate, pin) {
+    var command = shouldUpdate ? '/update' : '/install';
+    if (shouldLaunch) {
+        command += 'launch';
+    }
+
+    return run(this.path, [command, pathToAppxPackage, '/targetdevice:' + targetDevice.__shorthand]);
+};
+
+AppDeployCmdTool.prototype.uninstallAppPackage = function(packageInfo, targetDevice) {
+    return run(this.path, ['/uninstall', packageInfo, '/targetdevice:' + targetDevice.__shorthand]);
+};
+
+AppDeployCmdTool.prototype.launchApp = function(packageInfo, targetDevice) {
+    return run(this.path, ['/launch', packageInfo, '/targetdevice:' + targetDevice.__shorthand]);
+};
+
+function WinAppDeployCmdTool(targetOsVersion) {
+    if (!(this instanceof WinAppDeployCmdTool))
+        throw new ReferenceError('Only create a WinAppDeployCmdTool as an instance object.');
+
+    DeploymentTool.call(this);
+    this.targetOsVersion = targetOsVersion;
+    /* jshint ignore:start */ /* Ignore jshint to use dot notation for 2nd process.env access for consistency */
+    var programFilesPath = process.env['ProgramFiles(x86)'] || process.env['ProgramFiles'];
+    this.path = path.join(programFilesPath, 'Windows Kits', '10', 'bin', 'x86', 'WinAppDeployCmd.exe');
+    /* jshint ignore:end */
+}
+
+WinAppDeployCmdTool.prototype = Object.create(WinAppDeployCmdTool);
+WinAppDeployCmdTool.prototype.constructor = WinAppDeployCmdTool;
+
+WinAppDeployCmdTool.prototype.enumerateDevices = function() {
+    var that = this;
+    // 127.0.0.1   00000015-b21e-0da9-0000-000000000000    Lumia 1520 (RM-940)\r
+    //  maps to
+    // [(line), '127.0.0.1', '00000015-b21e-0da9-0000-000000000000', 'Lumia 1520 (RM-940)']
+    // The expansion is: IP address, spaces, GUID, spaces, text name
+    var LINE_TEST = /^([\d\.]+?)\s+([\da-fA-F\-]+?)\s+(.+)$/m;
+
+    return run(that.path, ['devices']).then(function(result) {
+        var lines = result.split('\n');
+        var matchedLines = lines.filter(function(line) {
+            return LINE_TEST.test(line);
+        });
+
+        var devices = matchedLines.map(function(line, arrayIndex) {
+            var match = line.match(LINE_TEST);
+            var ip = match[1];
+            var guid = match[2];
+            var name = match[3];
+            var type = 'device';
+
+            var deviceInfo = new DeviceInfo(arrayIndex, name, type);
+            deviceInfo.__ip = ip;
+            deviceInfo.__guid = guid;
+
+            return deviceInfo;
+        });
+
+        return devices;
+    });
+};
+
+WinAppDeployCmdTool.prototype.installAppPackage = function(pathToAppxPackage, targetDevice, shouldLaunch, shouldUpdate, pin) {
+    if (shouldLaunch) {
+        console.warn('Warning: Cannot launch app with current version of Windows 10 SDK tools.');
+        console.warn('         You will have to launch the app after installation is completed.');
+    }
+
+    var args = [shouldUpdate ? 'update' : 'install', '-file', pathToAppxPackage, '-ip', targetDevice.__ip];
+    if (pin) {
+        args.push('-pin');
+        args.push(pin);
+    }
+
+    return run(this.path, args).then(function() {
+        console.log('Deployment completed successfully.');
+    });
+};
+
+WinAppDeployCmdTool.prototype.uninstallAppPackage = function(packageInfo, targetDevice) {
+    return run(this.path, ['uninstall', '-package', packageInfo, '-ip', targetDevice.__ip]);
+};
+
+// usage: require('deployment').getDeploymentTool('8.1');
+module.exports = DeploymentTool;

--- a/template/cordova/lib/run.js
+++ b/template/cordova/lib/run.js
@@ -43,7 +43,7 @@ module.exports.run = function (argv) {
     // parse arg
     var args  = nopt({'debug': Boolean, 'release': Boolean, 'nobuild': Boolean,
         'device': Boolean, 'emulator': Boolean, 'target': String, 'archs': String,
-        'phone': Boolean, 'win': Boolean, 'appx': String}, {'r' : '--release'}, argv);
+        'phone': Boolean, 'win': Boolean, 'appx': String, 'win10tools': Boolean }, {'r' : '--release'}, argv);
 
     // Validate args
     if (args.debug && args.release) {
@@ -113,12 +113,12 @@ module.exports.run = function (argv) {
         console.log('\nDeploying ' + pkg.type + ' package to ' + deployTarget + ':\n' + pkg.appx);
         switch (pkg.type) {
             case 'phone':
-                return packages.deployToPhone(pkg, deployTarget, false).catch(function(e) {
+                return packages.deployToPhone(pkg, deployTarget, args.win10tools).catch(function(e) {
                     if (args.target || args.emulator || args.device) {
                         throw e; // Explicit target, carry on
                     }
                     // 'device' was inferred initially, because no target was specified
-                    return packages.deployToPhone(pkg, 'emulator', false);
+                    return packages.deployToPhone(pkg, 'emulator', args.win10tools);
                 });
             case 'windows10':
                 if (args.phone) {
@@ -128,7 +128,7 @@ module.exports.run = function (argv) {
                         console.warn('If you want to deploy to emulator, please use Visual Studio instead.');
                         console.warn('Attempting to deploy to device...');
                     }
-                    return packages.deployToPhone(pkg, 'device', true);
+                    return packages.deployToPhone(pkg, deployTarget, true);
                 }
                 else {
                     return packages.deployToDesktop(pkg, deployTarget, projectType);
@@ -155,7 +155,8 @@ module.exports.help = function () {
     console.log('    --appx=<8.1-win|8.1-phone|uap>');
     console.log('                  : Overrides windows-target-version to build Windows 8.1, ');
     console.log('                              Windows Phone 8.1, or Windows 10.');
-    console.log('');
+    console.log('    --win10tools  : Uses Windows 10 deployment tools (used for a Windows 8.1 app when');
+    console.log('                         being deployed to a Windows 10 device)');
     console.log('Examples:');
     console.log('    run');
     console.log('    run --emulator');


### PR DESCRIPTION
The Windows 10 SDK uses a new "WinAppDeployCmd" utility for deployment to phones.  This change abstracts out the differences between Windows 8.1 and Windows 10 and the substantially different utility interfaces and factors that out into a separate deployment module.