### PR TITLE
CB-9359: Adds support for .appxbundle creation

### DIFF
--- a/spec/unit/build.spec.js
+++ b/spec/unit/build.spec.js
@@ -39,6 +39,12 @@ function createFindAvailableVersionMock(version, path, buildSpy) {
     });
 }
 
+function createFindAllAvailableVersionsMock(versionSet) {
+    build.__set__('MSBuildTools.findAllAvailableVersions', function() {
+        return Q.resolve(versionSet);
+    });
+}
+
 function createConfigParserMock(winVersion, phoneVersion) {
     build.__set__('ConfigParser', function() {
         return {
@@ -99,7 +105,7 @@ describe('run method', function() {
             buildSpy = jasmine.createSpy();
 
         build.__set__('utils.isCordovaProject', isCordovaProjectFalse);
-        createFindAvailableVersionMock('14.0', testPath, buildSpy);
+        createFindAllAvailableVersionsMock([{version: '14.0', buildProject: buildSpy, path: testPath }]);
 
         build.run([ 'node', buildPath, '--release', '--debug' ])
         .fail(rejectSpy)
@@ -148,7 +154,7 @@ describe('run method', function() {
         });
 
         build.__set__('utils.isCordovaProject', isCordovaProjectTrue);
-        createFindAvailableVersionMock('14.0', testPath, buildSpy);
+        createFindAllAvailableVersionsMock([{version: '14.0', buildProject: buildSpy, path: testPath }]);
         build.__set__('prepare.applyPlatformConfig', function() {} );
 
         build.run([ 'node', buildPath, '--release' ])
@@ -164,7 +170,7 @@ describe('run method', function() {
         });
 
         build.__set__('utils.isCordovaProject', isCordovaProjectTrue);
-        createFindAvailableVersionMock('14.0', testPath, buildSpy);
+        createFindAllAvailableVersionsMock([{version: '14.0', buildProject: buildSpy, path: testPath }]);
         build.__set__('prepare.applyPlatformConfig', function() {} );
 
         build.run([ 'node', buildPath ])
@@ -180,7 +186,7 @@ describe('run method', function() {
         });
 
         build.__set__('utils.isCordovaProject', isCordovaProjectTrue);
-        createFindAvailableVersionMock('14.0', testPath, buildSpy);
+        createFindAllAvailableVersionsMock([{version: '14.0', buildProject: buildSpy, path: testPath }]);
         build.__set__('prepare.applyPlatformConfig', function() {} );
 
         build.run([ 'node', buildPath, '--archs=arm' ])
@@ -197,11 +203,11 @@ describe('run method', function() {
             anyCpuBuild = jasmine.createSpy();
 
         build.__set__('utils.isCordovaProject', isCordovaProjectTrue);
-        build.__set__('MSBuildTools.findAvailableVersion', function() {
-            return Q.resolve({
+        createFindAllAvailableVersionsMock([
+            {
                 version: '14.0',
                 path: testPath,
-                buildProject: function (solutionFile, buildType, buildArch) {
+                buildProject: function(solutionFile, buildType, buildArch) {
                     expect(buildArch).toMatch(/^arm$|^any\s?cpu$|^x86$|^x64$/);
                     switch (buildArch) {
                         case 'arm':
@@ -221,8 +227,7 @@ describe('run method', function() {
                             return Q.reject();
                     }
                 }
-            });
-        });
+             }]);
         build.__set__('prepare.applyPlatformConfig', function() {} );
 
         build.run([ 'node', buildPath, '--archs=arm x86 x64 anycpu', '--phone' ])
@@ -239,7 +244,7 @@ describe('run method', function() {
         var buildSpy = jasmine.createSpy();
 
         build.__set__('utils.isCordovaProject', isCordovaProjectTrue);
-        createFindAvailableVersionMock('4.0', testPath, buildSpy);
+        createFindAllAvailableVersionsMock([{version: '4.0', buildProject: buildSpy, path: testPath }]);
         build.__set__('prepare.applyPlatformConfig', function() {} );
         createConfigParserMock('8.0');
 
@@ -254,7 +259,7 @@ describe('run method', function() {
         var buildSpy = jasmine.createSpy();
 
         build.__set__('utils.isCordovaProject', isCordovaProjectTrue);
-        createFindAvailableVersionMock('14.0', testPath, buildSpy);
+        createFindAllAvailableVersionsMock([{version: '14.0', buildProject: buildSpy, path: testPath }]);
         build.__set__('prepare.applyPlatformConfig', function() {} );
         createConfigParserMock('8.1');
 
@@ -290,7 +295,7 @@ describe('run method', function() {
         var buildSpy = jasmine.createSpy();
 
         build.__set__('utils.isCordovaProject', isCordovaProjectTrue);
-        createFindAvailableVersionMock('14.0', testPath, buildSpy);
+        createFindAllAvailableVersionsMock([{version: '14.0', buildProject: buildSpy, path: testPath }]);
         build.__set__('prepare.applyPlatformConfig', function() {} );
         createConfigParserMock(null, '8.1');
 
@@ -330,6 +335,7 @@ describe('run method', function() {
 
         build.__set__('utils.isCordovaProject', isCordovaProjectTrue);
         createFindAvailableVersionMock('14.0', testPath, buildSpy);
+        createFindAllAvailableVersionsMock([{version: '14.0', buildProject: buildSpy, path: testPath }]);
         build.__set__('prepare.applyPlatformConfig', function() {} );
         // provision config to target Windows 8.1
         createConfigParserMock('8.1', '8.1');

--- a/spec/unit/package.spec.js
+++ b/spec/unit/package.spec.js
@@ -48,16 +48,16 @@ describe('getPackage method', function() {
         var rejected = jasmine.createSpy();
 
         pkg.getPackage('windows80', 'debug', 'anycpu')
-        .then(function(pkgInfo) {
-            expect(pkgInfo.type).toBe('windows80');
-            expect(pkgInfo.buildtype).toBe('debug');
-            expect(pkgInfo.arch).toBe('anycpu');
-            expect(pkgInfo.script).toBeDefined();
-        }, rejected)
-        .finally(function() {
-            expect(rejected).not.toHaveBeenCalled();
-            done();
-        });
+            .then(function(pkgInfo) {
+                expect(pkgInfo.type).toBe('windows80');
+                expect(pkgInfo.buildtype).toBe('debug');
+                expect(pkgInfo.arch).toBe('anycpu');
+                expect(pkgInfo.script).toBeDefined();
+            }, rejected)
+            .finally(function() {
+                expect(rejected).not.toHaveBeenCalled();
+                done();
+            });
     });
 
     it('spec.2 should find windows phone anycpu debug package', function(done) {

--- a/template/CordovaApp.Phone.jsproj
+++ b/template/CordovaApp.Phone.jsproj
@@ -59,6 +59,10 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>31b67a35-9503-4213-857e-f44eb42ae549</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Label="CordovaBuildParameters" Condition="'$(CordovaBundlePlatforms)' != ''">
+    <AppxBundle>Always</AppxBundle>
+    <AppxBundlePlatforms>$(CordovaBundlePlatforms)</AppxBundlePlatforms>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0'">
     <VisualStudioVersion>12.0</VisualStudioVersion>

--- a/template/CordovaApp.Windows.jsproj
+++ b/template/CordovaApp.Windows.jsproj
@@ -59,6 +59,10 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>58950fb6-2f93-4963-b9cd-637f83f3efbf</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Label="CordovaBuildParameters" Condition="'$(CordovaBundlePlatforms)' != ''">
+    <AppxBundle>Always</AppxBundle>
+    <AppxBundlePlatforms>$(CordovaBundlePlatforms)</AppxBundlePlatforms>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0'">
     <VisualStudioVersion>12.0</VisualStudioVersion>

--- a/template/CordovaApp.Windows10.jsproj
+++ b/template/CordovaApp.Windows10.jsproj
@@ -60,6 +60,10 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>f9b0ae20-c91c-42b9-9c6e-d3bc28b4509e</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Label="CordovaBuildParameters" Condition="'$(CordovaBundlePlatforms)' != ''">
+    <AppxBundle>Always</AppxBundle>
+    <AppxBundlePlatforms>$(CordovaBundlePlatforms)</AppxBundlePlatforms>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0'">
     <VisualStudioVersion>14.0</VisualStudioVersion>
@@ -71,6 +75,7 @@
     <TargetPlatformVersion>10.0.10030.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10030.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <UapDefaultAssetScale>100</UapDefaultAssetScale>
   </PropertyGroup>
   <!--
     MSBuild\12.0\Bin\Microsoft.Common.CurrentVersion.targets contains a "TargetPlatformVersion" check, which will throw if

--- a/template/cordova/lib/MSBuildTools.js
+++ b/template/cordova/lib/MSBuildTools.js
@@ -29,7 +29,7 @@ function MSBuildTools (version, path) {
     this.path = path;
 }
 
-MSBuildTools.prototype.buildProject = function(projFile, buildType, buildarch) {
+MSBuildTools.prototype.buildProject = function(projFile, buildType, buildarch, otherConfigProperties) {
     console.log('Building project: ' + projFile);
     console.log('\tConfiguration : ' + buildType);
     console.log('\tPlatform      : ' + buildarch);
@@ -37,6 +37,13 @@ MSBuildTools.prototype.buildProject = function(projFile, buildType, buildarch) {
     var args = ['/clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal', '/nologo',
     '/p:Configuration=' + buildType,
     '/p:Platform=' + buildarch];
+
+    if (otherConfigProperties) {
+        var keys = Object.keys(otherConfigProperties);
+        keys.forEach(function(key) {
+            args.push('/p:' + key + '=' + otherConfigProperties[key]);
+        });
+    }
 
     return spawn(path.join(this.path, 'msbuild'), [projFile].concat(args));
 };
@@ -50,6 +57,16 @@ module.exports.findAvailableVersion = function () {
         var msbuildTools = versions[0] || versions[1] || versions[2];
 
         return msbuildTools ? Q.resolve(msbuildTools) : Q.reject('MSBuild tools not found');
+    });
+};
+
+module.exports.findAllAvailableVersions = function () {
+    var versions = ['14.0', '12.0', '4.0'];
+
+    return Q.all(versions.map(checkMSBuildVersion)).then(function(unprocessedResults) {
+        return unprocessedResults.filter(function(item) {
+            return !!item;
+        });
     });
 };
 

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -23,6 +23,7 @@ var Q     = require('Q'),
     shell = require('shelljs'),
     utils = require('./utils'),
     prepare = require('./prepare'),
+    package = require('./package'),
     MSBuildTools = require('./MSBuildTools'),
     ConfigParser = require('./ConfigParser'),
     fs = require('fs');
@@ -39,21 +40,22 @@ var projFiles = {
 // builds cordova-windows application with parameters provided.
 // See 'help' function for args list
 module.exports.run = function run (argv) {
-    // MSBuild Tools available on this development machine
-    var msbuild;
 
     if (!utils.isCordovaProject(ROOT)){
         return Q.reject('Could not find project at ' + ROOT);
     }
 
-    return Q.all([parseAndValidateArgs(argv), MSBuildTools.findAvailableVersion()])
+    return Q.all([parseAndValidateArgs(argv), MSBuildTools.findAllAvailableVersions()])
         .spread(function(buildConfig, msbuildTools) {
             // Apply build related configs
             prepare.updateBuildConfig(buildConfig);
+            // bug: Windows 8 build fails on a system with MSBuild 14 on it.
+            // Don't regress, make sure MSBuild 4 is selected for a Windows 8 build.
             cleanIntermediates();
-            msbuild = msbuildTools;
-            console.log('MSBuildToolsPath: ' + msbuild.path);
-            return buildTargets(msbuild, buildConfig);
+            return buildTargets(msbuildTools, buildConfig).then(function(pkg) {
+                console.log(' BUILD OUTPUT: ' + pkg.appx);
+                return pkg;
+            });
         }, function(error) {
             return Q.reject(error);
         });
@@ -62,20 +64,21 @@ module.exports.run = function run (argv) {
 // help/usage function
 module.exports.help = function help() {
     console.log('');
-    console.log('Usage: build [--debug | --release] [--archs="<list of architectures...>"]');
-    console.log('             [--phone | --win] [--packageCertificateKeyFile="key path"]');
+    console.log('Usage: build [--debug | --release] [--phone | --win] [--bundle]');
+    console.log('             [--archs="<list of architectures...>"');
+    console.log('             [--packageCertificateKeyFile="key path"]');
     console.log('             [--packageThumbprint="thumbprint"] [--publisherId]');
     console.log('             [--buildConfig="file path"]');
     console.log('    --help                      : Displays this dialog.');
     console.log('    --debug                     : Builds project in debug mode. (Default).');
-    console.log('    --release                   : Builds project in release mode.');
-    console.log('    -r                          : (shortcut) Builds project in release mode.');
+    console.log('    --release  (-r)             : Builds project in release mode.');
+    console.log('    --phone, --win              : Specifies, what type of project to build.');
+    console.log('    --bundle                    : Tells the compiler to create a .appxbundle.');
+    console.log('                                  Bundling is disabled when `anycpu` is built.');
     console.log('    --archs                     : Builds project binaries for specific chip');
     console.log('                                  architectures (`anycpu`, `arm`, `x86`, `x64`).');
     console.log('                                  Separate multiple choices with spaces and if');
     console.log('                                  passing multiple choices, enclose with " ".');
-    console.log('    --phone, --win');
-    console.log('                                : Specifies, what type of project to build.');
     console.log('    --appx=<8.1-win|8.1-phone|uap>');
     console.log('                                : Overrides windows-target-version to build');
     console.log('                                  Windows 8.1, Windows Phone 8.1, or');
@@ -89,7 +92,7 @@ module.exports.help = function help() {
     console.log('    build ');
     console.log('    build --debug');
     console.log('    build --release');
-    console.log('    build --release --archs="arm x86"');
+    console.log('    build --release --archs="arm x86" --bundle');
     console.log('    build --appx=8.1-phone -r');
     console.log('    build --packageCertificateKeyFile="CordovaApp_TemporaryKey.pfx"');
     console.log('    build --publisherId="CN=FakeCorp, C=US"');
@@ -175,6 +178,7 @@ function parseAndValidateArgs(argv) {
             'appx': String,
             'phone': Boolean,
             'win': Boolean,
+            'bundle': Boolean,
             'packageCertificateKeyFile': String,
             'packageThumbprint': String,
             'publisherId': String,
@@ -199,7 +203,16 @@ function parseAndValidateArgs(argv) {
         config.buildArchs = args.archs ? args.archs.split(' ') : ['anycpu'];
         config.phone = args.phone ? true : false;
         config.win = args.win ? true : false;
-        config.projOverride = args.appx;
+        config.projVerOverride = args.appx;
+        // only set config.bundle if architecture is not anycpu
+        if (args.bundle) {
+            if ((config.buildArchs.indexOf('anycpu') > -1 || config.buildArchs.indexOf('any cpu') > -1) && config.buildArchs.length > 1) {
+                // Not valid to bundle anycpu with cpu-specific architectures.  warn, then don't bundle
+                console.warn('Warning: anycpu and CPU-specific architectures were selected. This is not valid');
+                console.warn(' when enabling bundling with --bundle.  Disabling bundling for this build.');
+            }
+            config.bundle = true;
+        }
 
         // if build.json is provided, parse it
         var buildConfigPath = args.buildConfig;
@@ -216,7 +229,6 @@ function parseAndValidateArgs(argv) {
 
         config.packageThumbprint = config.packageThumbprint || args.packageThumbprint;
         config.publisherId = config.publisherId || args.publisherId;
-
         resolve(config);
     });
 }
@@ -268,11 +280,26 @@ function parseBuildConfig(buildConfigPath, config) {
     return result;
 }
 
-function buildTargets(msbuild, config) {
+function buildTargets(allMsBuildVersions, config) {
     // filter targets to make sure they are supported on this development machine
-    var myBuildTargets = filterSupportedTargets(module.exports.getBuildTargets(config.win, config.phone, config.projOverride), msbuild);
+    var selectedBuildTargets = getBuildTargets(config);
+    var msbuild = getMsBuildForTargets(selectedBuildTargets, config, allMsBuildVersions); 
+    if (!msbuild) {
+        return Q.reject('No valid MSBuild was detected for the selected target.');
+    }
+    console.log('MSBuildToolsPath: ' + msbuild.path);
+    var myBuildTargets = filterSupportedTargets(selectedBuildTargets, msbuild);
 
     var buildConfigs = [];
+    var bundleTerms = '';
+    var hasAnyCpu = false;
+    var shouldBundle = !!config.bundle;
+    if (myBuildTargets.indexOf(projFiles.win80) > -1) {
+        if (shouldBundle) {
+            console.warn('Warning: Bundling is disabled because a Windows 8 project was detected.');
+        }
+        shouldBundle = false;
+    }
 
     // collect all build configurations (pairs of project to build and target architecture)
     myBuildTargets.forEach(function(buildTarget) {
@@ -281,11 +308,23 @@ function buildTargets(msbuild, config) {
                 target:buildTarget,
                 arch: buildArch
             });
+
+            if (buildArch === 'anycpu' || buildArch === 'any cpu') {
+                hasAnyCpu = true;
+                bundleTerms = 'neutral';
+            }
+
+            if (!hasAnyCpu) {
+                if (bundleTerms.length > 0) {
+                    bundleTerms += '|';
+                }
+                bundleTerms += buildArch;
+            }
         });
     });
 
     // run builds serially
-    return buildConfigs.reduce(function (promise, build) {
+    var buildsCompleted = buildConfigs.reduce(function (promise, build, index, configsArray) {
          return promise.then(function () {
             // support for "any cpu" specified with or without space
             if (build.arch == 'any cpu') {
@@ -295,9 +334,179 @@ function buildTargets(msbuild, config) {
             if (msbuild.version == '4.0' && build.target == projFiles.win80) {
                 build.target = 'CordovaApp.vs2012.sln';
             }
-            return msbuild.buildProject(path.join(ROOT, build.target), config.buildType,  build.arch);
+
+            var otherProperties = { };
+            // Only add the CordovaBundlePlatforms argument when on the last build step
+            if (shouldBundle && index === configsArray.length - 1) {
+                otherProperties.CordovaBundlePlatforms = bundleTerms;
+            } else if (shouldBundle) {
+                otherProperties.CordovaBundlePlatforms = build.arch;
+            }
+            return msbuild.buildProject(path.join(ROOT, build.target), config.buildType,  build.arch, otherProperties);
          });
     }, Q());
+
+    if (shouldBundle) {
+        return buildsCompleted.then(function() {
+            return clearIntermediatesAndGetPackage(bundleTerms, config, hasAnyCpu);
+        });
+    } else {
+        return buildsCompleted.then(function() {
+            return package.getPackage(config.targetProject, config.buildType, config.buildArchs[0]);
+        });
+    }
+}
+
+function clearIntermediatesAndGetPackage(bundleTerms, config, hasAnyCpu) {
+    // msbuild isn't capable of generating bundles unless you enable bundling for each individual arch
+    // However, that generates intermediate bundles, like "CordovaApp.Windows10_0.0.1.0_x64.appxbundle"
+    // We need to clear the intermediate bundles, or else "cordova run" will fail because of too
+    // many .appxbundle files.
+
+    console.log('Clearing intermediates...');
+    var appPackagesPath = path.join(ROOT, 'AppPackages');
+    var childDirectories = shell.ls(path.join(appPackagesPath, '*')).map(function(pathName) {
+        return { path: pathName, stats: fs.statSync(pathName) };
+    }).filter(function(fileInfo) {
+        return fileInfo.stats.isDirectory();
+    });
+
+    if (childDirectories.length === 0) {
+        throw new Error('Could not find a completed app package directory.');
+    }
+
+    // find the most-recently-modified directory
+    childDirectories.sort(function(a, b) { return b.stats.mtime - a.stats.mtime; });
+    var outputDirectory = childDirectories[0];
+
+    var finalFile = '';
+    var archSearchString = bundleTerms.replace(/\|/g, '_') + (config.buildType === 'debug' ? '_debug' : '') + '.appxbundle';
+    if (hasAnyCpu) {
+        archSearchString = 'AnyCPU' + (config.buildType === 'debug' ? '_debug' : '') + '.appxbundle';
+    }
+    
+    var filesToDelete = shell.ls(path.join(outputDirectory.path, '*.appx*')).filter(function(appxbundle) {
+        var isMatch = appxbundle.indexOf(archSearchString) === -1;
+        if (!isMatch) {
+            finalFile = appxbundle;
+        }
+        return isMatch;
+    });
+    filesToDelete.forEach(function(file) {
+        shell.rm(file);
+    });
+
+    return package.getPackageFileInfo(finalFile);
+}
+
+// Can update buildConfig in the following ways:
+//  * Sets targetProject property, the project to launch when complete
+function getBuildTargets(buildConfig) {
+    var configXML = new ConfigParser(path.join(ROOT, 'config.xml'));
+    var targets = [];
+    var noSwitches = !(buildConfig.phone || buildConfig.win);
+
+    // Windows
+    if (buildConfig.win || noSwitches) { // if --win or no arg
+        var windowsTargetVersion = configXML.getWindowsTargetVersion();
+        switch(windowsTargetVersion) {
+        case '8':
+        case '8.0':
+            targets.push(projFiles.win80);
+            break;
+        case '8.1':
+            targets.push(projFiles.win);
+            break;
+        case '10.0':
+        case 'UAP':
+            targets.push(projFiles.win10);
+            break;
+        default:
+            throw new Error('Unsupported windows-target-version value: ' + windowsTargetVersion);
+        }
+    }
+
+    // Windows Phone
+    if (buildConfig.phone || noSwitches) { // if --phone or no arg
+        var windowsPhoneTargetVersion = configXML.getWindowsPhoneTargetVersion();
+        switch(windowsPhoneTargetVersion) {
+        case '8.1':
+            targets.push(projFiles.phone);
+            break;
+        case '10.0':
+        case 'UAP':
+            if (!buildConfig.win && !noSwitches) {
+                // Already built due to --win or no switches
+                // and since the same thing can be run on Phone as Windows,
+                // we can skip this one.
+                targets.push(projFiles.win10);
+            }
+            break;
+        default:
+            throw new Error('Unsupported windows-phone-target-version value: ' + windowsPhoneTargetVersion);
+        }
+    }
+
+    // apply build target override if one was specified
+    if (buildConfig.projVerOverride) {
+        switch (buildConfig.projVerOverride) {
+            case '8.1-phone':
+                targets = [projFiles.phone];
+                break;
+            case '8.1-win':
+                targets = [projFiles.win];
+                break;
+            case 'uap':
+                targets = [projFiles.win10];
+                break;
+            default:
+                console.warn('Unrecognized --appx parameter passed to build: "' + buildConfig.projVerOverride + '", ignoring.');
+                break;
+        }
+    }
+
+    // As part of reworking how build and package determine the winning project, set the 'target type' project
+    // as part of build configuration.  This will be used for determining the binary to 'run' after build is done.
+    if (targets.length > 0) {
+        switch (targets[0]) {
+            case projFiles.win80:
+                buildConfig.targetProject = 'windows80';
+                break;
+            case projFiles.phone:
+                buildConfig.targetProject = 'phone';
+                break;
+            case projFiles.win10:
+                buildConfig.targetProject = 'windows10';
+                break;
+            case projFiles.win:
+                /* falls through */
+            default:
+                buildConfig.targetProject = 'windows';
+                break;
+        }
+    }
+
+    return targets;
+}
+
+function getMsBuildForTargets(selectedTargets, buildConfig, allMsBuildVersions) {
+    var availableVersions = allMsBuildVersions.reduce(function(obj, msbuildVersion) {
+        obj[msbuildVersion.version] = msbuildVersion;
+        return obj;
+    }, {});
+
+    var result = null;
+
+    if (selectedTargets.indexOf(projFiles.win80) > -1) {
+        // building Windows 8; prefer 4.0, unless phone is also present, in which case prefer 12
+        // prefer 12.  If not present, can't build this; error in the filterSupportedTargets function
+        result = availableVersions['12.0'] || availableVersions['4.0']; 
+    } else {
+        // 14 can build Windows 10, Windows 8.1, and Windows Phone 8.1, so resolve to 14 if available, else 12
+        result = (availableVersions['14.0'] || availableVersions['12.0']);
+    }
+
+    return result;
 }
 
 // TODO: Fix this so that it outlines supported versions based on version criteria:

--- a/template/cordova/lib/run.js
+++ b/template/cordova/lib/run.js
@@ -70,12 +70,17 @@ module.exports.run = function (argv) {
      // what project type we should deploy
      var projectType = projFileToType(buildTargets[0]);
 
-    // if --nobuild isn't specified then build app first
-    var buildPackages = args.nobuild ? Q() : build.run(argv);
+    if (projectType === 'windows80' && argv.indexOf('--bundle') > -1) {
+        // Don't enable bundling for Windows 8.
+        // Assumes the commander only enters the --bundle param once
+        argv.splice(argv.indexOf('--bundle'), 1);
+    }
 
-    return buildPackages.then(function () {
-        return packages.getPackage(projectType, buildType, buildArchs[0]);
-    }).then(function(pkg) {
+    // if --nobuild isn't specified then build app first
+    var buildPackages = args.nobuild ? packages.getPackage(projectType, buildType, buildArchs) : build.run(argv);
+
+    // buildPackages also deploys bundles
+    return buildPackages.then(function(pkg) {
         console.log('\nDeploying ' + pkg.type + ' package to ' + deployTarget + ':\n' + pkg.appx);
         switch (pkg.type) {
             case 'phone':
@@ -108,7 +113,7 @@ module.exports.run = function (argv) {
 
 module.exports.help = function () {
     console.log('\nUsage: run [ --device | --emulator | --target=<id> ] [ --debug | --release | --nobuild ]');
-    console.log('           [ --x86 | --x64 | --arm ] [--phone | --win]');
+    console.log('           [ --x86 | --x64 | --arm | --archs="list" ] [--bundle] [--phone | --win]');
     console.log('    --device      : Deploys and runs the project on the connected device.');
     console.log('    --emulator    : Deploys and runs the project on an emulator.');
     console.log('    --target=<id> : Deploys and runs the project on the specified target.');
@@ -118,6 +123,8 @@ module.exports.help = function () {
     console.log('    --archs       : Specific chip architectures (`anycpu`, `arm`, `x86`, `x64`).');
     console.log('                        Separate multiple choices with a space and, if choosing');
     console.log('                        multiple choices, enclose in quotes (").');
+    console.log('    --bundle      : Generates an .appxbundle. Not valid if anycpu AND chip-specific');
+    console.log('                    architectures are used.');
     console.log('    --phone, --win');
     console.log('                  : Specifies project type to deploy');
     console.log('    --appx=<8.1-win|8.1-phone|uap>');
@@ -131,6 +138,7 @@ module.exports.help = function () {
     console.log('    run --target=7988B8C3-3ADE-488d-BA3E-D052AC9DC710');
     console.log('    run --device --release');
     console.log('    run --emulator --debug');
+    console.log('    run --archs="x64 x86 arm" --no-bundle');
     console.log('    run --device --appx=phone-8.1');
     console.log('    run --device --archs="x64 x86 arm"');
     console.log('');


### PR DESCRIPTION
.appxbundle files are convenient app packages which can be uploaded to the Windows Store.  They contain debug or release (typically release) versions of more than one of the x86, x64, and ARM architecture builds.

To enable bundling, simply build for multiple architectures:

    cordova build windows -- --archs="x86 x64 arm"

Bundling is disabled if `anycpu` is one of the architectures (or is the default architecture).  You can explicitly disable bundling by passing the `--no-bundle` flag:

    cordova build windows -- --archs="x86 x64 arm" --no-bundle

Bundling is not supported for Windows 8 as the feature is not available for that platform in general.