### PR TITLE
CB-9408: Added a `windows-packageVersion` attribute to the `<widget>`

### DIFF
--- a/spec/unit/Prepare.Win10.spec.js
+++ b/spec/unit/Prepare.Win10.spec.js
@@ -116,9 +116,10 @@ describe('Min/Max UAP versions are correctly read from the config file.', functi
   * Unit tests for validating default ms-appx-web:// URI scheme in Win10
   * (for the function applyCoreProperties) from prepare.js.
   **/
-function createMockConfigAndManifestForApplyCoreProperties(startPage, windowsDefaultUriPrefix, win10) {
+function createMockConfigAndManifestForApplyCoreProperties(startPage, windowsDefaultUriPrefix, win10, winPackageVersion) {
     var config = {
         version: function() { return '1.0.0.0'; },
+        windows_packageVersion: function() { return winPackageVersion; },
         name: function() { return 'HelloCordova'; },
         packageName: function() { return 'org.apache.cordova.HelloCordova'; },
         author: function() { return 'Apache'; },

--- a/template/cordova/lib/ConfigParser.js
+++ b/template/cordova/lib/ConfigParser.js
@@ -90,6 +90,9 @@ ConfigParser.prototype = {
     version: function() {
         return this.doc.getroot().attrib['version'];
     },
+    windows_packageVersion: function() {
+        return this.doc.getroot().attrib['windows-packageVersion'];
+    },
     android_versionCode: function() {
         return this.doc.getroot().attrib['android-versionCode'];
     },

--- a/template/cordova/lib/prepare.js
+++ b/template/cordova/lib/prepare.js
@@ -154,7 +154,7 @@ function updateManifestFile (config, manifestPath, namespacePrefix, uapVersionIn
 }
 
 function applyCoreProperties(config, manifest, manifestPath, xmlnsPrefix, targetWin10) {
-    var version = fixConfigVersion(config.version());
+    var version = fixConfigVersion(config.windows_packageVersion() || config.version());
     var name = config.name();
     var pkgName = config.packageName();
     var author = config.author();


### PR DESCRIPTION
...element which enables Windows to have a separate, independent binary
version than other platforms.  This attribute corresponds to similar
attributes `android-versionCode` and `ios-CFBundleVersion`.