### PR TITLE
CB-9450: Added a manifest munge step during build that updates app...

### DIFF
--- a/spec/unit/Prepare.Win10.spec.js
+++ b/spec/unit/Prepare.Win10.spec.js
@@ -121,7 +121,8 @@ var PreferencesBaseline = {
     Orientation: null,
     WindowsDefaultUriPrefix: null,
     WindowsStoreDisplayName: null,
-    WindowsStorePublisherName: null
+    WindowsStorePublisherName: null,
+    WindowsStoreIdentityName: null
 };
 function createMockConfigAndManifestForApplyCoreProperties(startPage, preferences, win10, winPackageVersion) {
     if (!preferences) {

--- a/template/cordova/lib/prepare.js
+++ b/template/cordova/lib/prepare.js
@@ -155,7 +155,10 @@ function updateManifestFile (config, manifestPath, namespacePrefix, isTargetingW
 function applyCoreProperties(config, manifest, manifestPath, xmlnsPrefix, targetWin10) {
     var version = fixConfigVersion(config.windows_packageVersion() || config.version());
     var name = config.name();
-    var pkgName = config.packageName();
+    // CB-9450: iOS/Android and Windows Store have an incompatibility here; Windows Store assigns the 
+    // package name that should be used for upload to the store.  However, this can't be set for typical
+    // Cordova apps.  So, we have to create a Windows-specific preference here.
+    var pkgName = config.getPreference('WindowsStoreIdentityName') || config.packageName();
     var author = config.author();
 
     var identityNode = manifest.find('.//Identity');
@@ -181,10 +184,11 @@ function applyCoreProperties(config, manifest, manifestPath, xmlnsPrefix, target
         throw new Error('Invalid manifest file (no <Application> node): ' + manifestPath);
     }
 
-    if (pkgName) {
+    var baselinePackageName = config.packageName();
+    if (baselinePackageName) {
         // 64 symbols restriction goes from manifest schema definition
         // http://msdn.microsoft.com/en-us/library/windows/apps/br211415.aspx
-        var appId = pkgName.length <= 64 ? pkgName : pkgName.substr(0, 64);
+        var appId = baselinePackageName.length <= 64 ? baselinePackageName : baselinePackageName.substr(0, 64);
         app.attrib.Id = appId;
     }
 


### PR DESCRIPTION
...manifests with build and packaging parameters.  Also added the new
`WindowsStoreIdentityName` preference which adds the ability to set that
publishing property, since the Windows Store app identity is assigned by
the Store.