### PR TITLE
CB-9482: Modifies the deployment code to account for problems with

### DIFF
--- a/template/cordova/lib/deployment.js
+++ b/template/cordova/lib/deployment.js
@@ -204,7 +204,13 @@ AppDeployCmdTool.prototype.installAppPackage = function(pathToAppxPackage, targe
 };
 
 AppDeployCmdTool.prototype.uninstallAppPackage = function(packageInfo, targetDevice) {
-    return run(this.path, ['/uninstall', packageInfo, '/targetdevice:' + targetDevice.__shorthand]);
+    // CB-9482: AppDeployCmd reports failure when targeting an emulator, but actually succeeds
+    //  Further calls in the promise chain then are not executed (such as installAppPackage) because
+    //  of the failure reported here.  By ensuring that this function always reports a success
+    //  state, it allows install to proceed.  (Install will fail if there is a legitimate 
+    //  uninstall failure such as due to no device).  
+    var assureSuccess = function() {};
+    return run(this.path, ['/uninstall', packageInfo, '/targetdevice:' + targetDevice.__shorthand]).then(assureSuccess, assureSuccess);
 };
 
 AppDeployCmdTool.prototype.launchApp = function(packageInfo, targetDevice) {

--- a/template/cordova/lib/package.js
+++ b/template/cordova/lib/package.js
@@ -189,6 +189,7 @@ module.exports.deployToPhone = function (package, deployTarget, targetWindows10,
             return uninstallAppFromPhone(deploymentTool, package, target).then(
                 function() {}, function() {}).then(function() {
                     // shouldUpdate = false because we've already uninstalled
+                    console.log('Deploying app package...');
                     return deploymentTool.installAppPackage(package.appx, target, /*shouldLaunch*/ true, /*shouldUpdate*/ false);
                 }).then(function() { }, function(error) {
                     if (error.indexOf('Error code 2148734208 for command') === 0) {


### PR DESCRIPTION
emulators, which are currently blocking the CI from executing.  Modifying
the uninstall function to never fail appears to unblock the CI and allow
installation to emulators to continue unhindered.