### PR TITLE
CB-9482: Upon further investigation of CI failures, we saw that

### DIFF
--- a/template/cordova/lib/package.js
+++ b/template/cordova/lib/package.js
@@ -189,6 +189,7 @@ module.exports.deployToPhone = function (package, deployTarget, targetWindows10,
             return uninstallAppFromPhone(deploymentTool, package, target).then(
                 function() {}, function() {}).then(function() {
                     // shouldUpdate = false because we've already uninstalled
+                    console.log('Deploying app package...');
                     return deploymentTool.installAppPackage(package.appx, target, /*shouldLaunch*/ true, /*shouldUpdate*/ false);
                 }).then(function() { }, function(error) {
                     if (error.indexOf('Error code 2148734208 for command') === 0) {


### PR DESCRIPTION
AppDeployCmd also failed to install an app when:
 - The emulator had been off previously
 - It had been started with the AppDeployCmd /uninstall command
 - The next command was to then install an app

This change detects the condition (only for emulator targets) and retries
once.  This appears to correct the issue.