### PR TITLE
CB-9499: There is a run failure when trying to deploy an x64 app when…

### DIFF
--- a/template/CordovaApp.Windows10.jsproj
+++ b/template/CordovaApp.Windows10.jsproj
@@ -91,7 +91,6 @@
       <SubType>Designer</SubType>
     </AppxManifest>
     <Content Include="images\*.png" Exclude="images\*.scale-240.*" />
-    <Content Include="WinJS\js\base.js" />
   </ItemGroup>
   <Import Project="CordovaApp.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\$(WMSJSProjectDirectory)\Microsoft.VisualStudio.$(WMSJSProject).targets" />

--- a/template/cordova/lib/package.js
+++ b/template/cordova/lib/package.js
@@ -215,15 +215,25 @@ module.exports.deployToDesktop = function (package, deployTarget) {
 
     return utils.getAppStoreUtils().then(function(appStoreUtils) {
         return getPackageName(path.join(__dirname, '..', '..')).then(function(pkgname) {
+
+            var oldArch;
             // uninstalls previous application instance (if exists)
             console.log('Attempt to uninstall previous application version...');
             return spawn('powershell', ['-ExecutionPolicy', 'RemoteSigned', 'Import-Module "' + appStoreUtils + '"; Uninstall-App ' + pkgname])
             .then(function() {
                 console.log('Attempt to install application...');
+                oldArch = process.env.PROCESSOR_ARCHITECTURE;
+                if (package.arch === 'x64') {
+                    process.env.PROCESSOR_ARCHITECTURE = 'AMD64';
+                }
                 return spawn('powershell', ['-ExecutionPolicy', 'RemoteSigned', 'Import-Module "' + appStoreUtils + '"; Install-App', utils.quote(package.script)]);
             }).then(function() {
+                process.env.PROCESSOR_ARCHITECTURE = oldArch;
                 console.log('Starting application...');
                 return spawn('powershell', ['-ExecutionPolicy', 'RemoteSigned', 'Import-Module "' + appStoreUtils + '"; Start-Locally', pkgname]);
+            }, function (error) {
+                process.env.PROCESSOR_ARCHITECTURE = oldArch;
+                throw error;
             });
         });
     });


### PR DESCRIPTION
… running on an x86 version of Node.  This change addresses the problem by modifying the run process by detecting an x64 app package as the primary, and setting the environment architecture to x64 before invoking PowerShell.

Also, small build item to point to the correct location of WinJS.