### PR TITLE
Add support for back button on win10

### DIFF
--- a/cordova-js-src/platform.js
+++ b/cordova-js-src/platform.js
@@ -38,6 +38,24 @@ module.exports = {
             channel.onActivated = cordova.addDocumentEventHandler('activated');
         }
         channel.onNativeReady.fire();
+        
+        // Only load this code if we're running on Win10 in a non-emulated app frame, otherwise crash \o/
+        if (parseInt(window.clientInformation.userAgent.match(/Windows NT ([0-9.]+)/)[1]) >= 10) {
+            var sysnavman = Windows.UI.Core.SystemNavigationManager.getForCurrentView();
+            // Inject a listener for the backbutton on the document.
+            var backButtonChannel = cordova.addDocumentEventHandler('backbutton');
+            backButtonChannel.onHasSubscribersChange = function() {
+                // If we just attached the first handler or detached the last handler,
+                // let native know we need to override the back button.
+                sysnavman.appViewBackButtonVisibility = (this.numHandlers == 1);
+            };
+            
+            var backRequestedHandler = function backRequestedHandler() {
+                cordova.fireDocumentEvent('backbutton',null,true);
+                return true;
+            };
+            sysnavman.addEventListener("backrequested", backRequestedHandler, false);
+        }
 
         var onWinJSReady = function () {
             var app = WinJS.Application;


### PR DESCRIPTION
Win10 has support for backbutton through the SystemNavigationManager API 
https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.core.systemnavigationmanager.aspx 

Unfortunately there's some OS-level crashes that happen when running the app if it has been compiled with VS2012/2013, but they get detected with the userAgent check that the OS fakes when it runs the app container, so this code only works when compiling on VS2015 (or newer, I guess)