### PR TITLE
CB-9565: Build failure for Windows 10.  This error is a result of using

### DIFF
--- a/template/cordova/lib/MSBuildTools.js
+++ b/template/cordova/lib/MSBuildTools.js
@@ -77,7 +77,13 @@ function checkMSBuildVersion(version) {
         // fetch msbuild path from 'reg' output
         var path = /MSBuildToolsPath\s+REG_SZ\s+(.*)/i.exec(output);
         if (path) {
-            deferred.resolve(new MSBuildTools(version, path[1]));
+            path = path[1];
+            // CB-9565: Windows 10 invokes .NET Native compiler, which only runs on x86 arch,
+            // so if we're running an x64 Node, make sure to use x86 tools.
+            if (version === '14.0' && path.indexOf('amd64')) {
+                path = require('path').join(path, '..');
+            }
+            deferred.resolve(new MSBuildTools(version, path));
             return;
         }
         deferred.resolve(null); // not found


### PR DESCRIPTION
This error is a result of using x64 Node and an incompatibility with x64 msbuild; the .NET Native compiler is x86 only (for where it can run).  As a result, when msbuild-x64 tries to use it, it fails.  This works around the issue by running x86 instead.