### PR TITLE
remove publisherId since its overridden by the certficate during build

### DIFF
--- a/template/cordova/lib/prepare.js
+++ b/template/cordova/lib/prepare.js
@@ -173,11 +173,6 @@ function applyCoreProperties(config, manifest, manifestPath, xmlnsPrefix, target
         (identityNode.attrib.Version = version);
     }
 
-    // Update publisher id (identity)
-    if (config.publisherId && identityNode.attrib.Publisher !== config.publisherId) {
-        identityNode.attrib.Publisher = config.publisherId;
-    }
-
     // Update name (windows8 has it in the Application[@Id] and Application.VisualElements[@DisplayName])
     var app = manifest.find('.//Application');
     if(!app) {


### PR DESCRIPTION
1. The publisherId set here is __always__ overridden by the `CN` from the projects associated certificate. That is by default, the Cordova certificate that has `CN=The Cordova Team`. Therefor the resulting `AppxManifest.xml` will always have `Publisher="CN=The Cordova Team"` set regardless of what one puts into `publisherId`.