### PR TITLE
CB-10292: Windows platform support for next version of VS/MSBuild

### DIFF
--- a/template/cordova/lib/MSBuildTools.js
+++ b/template/cordova/lib/MSBuildTools.js
@@ -50,18 +50,18 @@ MSBuildTools.prototype.buildProject = function(projFile, buildType, buildarch, o
 
 // returns full path to msbuild tools required to build the project and tools version
 module.exports.findAvailableVersion = function () {
-    var versions = ['14.0', '12.0', '4.0'];
+    var versions = ['15.0', '14.0', '12.0', '4.0'];
 
     return Q.all(versions.map(checkMSBuildVersion)).then(function (versions) {
         // select first msbuild version available, and resolve promise with it
-        var msbuildTools = versions[0] || versions[1] || versions[2];
+        var msbuildTools = versions[0] || versions[1] || versions[2] || versions[3];
 
         return msbuildTools ? Q.resolve(msbuildTools) : Q.reject('MSBuild tools not found');
     });
 };
 
 module.exports.findAllAvailableVersions = function () {
-    var versions = ['14.0', '12.0', '4.0'];
+    var versions = ['15.0', '14.0', '12.0', '4.0'];
     events.emit('verbose', 'Searching for available MSBuild versions...');
 
     return Q.all(versions.map(checkMSBuildVersion)).then(function(unprocessedResults) {
@@ -80,7 +80,7 @@ function checkMSBuildVersion(version) {
             toolsPath = toolsPath[1];
             // CB-9565: Windows 10 invokes .NET Native compiler, which only runs on x86 arch,
             // so if we're running an x64 Node, make sure to use x86 tools.
-            if (version === '14.0' && toolsPath.indexOf('amd64') > -1) {
+            if ((version === '15.0' || version === '14.0') && toolsPath.indexOf('amd64') > -1) {
                 toolsPath = path.resolve(toolsPath, '..');
             }
             events.emit('verbose', 'Found MSBuild v' + version + ' at ' + toolsPath);

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -502,8 +502,8 @@ function getMsBuildForTargets(selectedTargets, buildConfig, allMsBuildVersions) 
         // prefer 12.  If not present, can't build this; error in the filterSupportedTargets function
         result = availableVersions['12.0'] || availableVersions['4.0'];
     } else {
-        // 14 can build Windows 10, Windows 8.1, and Windows Phone 8.1, so resolve to 14 if available, else 12
-        result = (availableVersions['14.0'] || availableVersions['12.0']);
+        // 15 and 14 can build Windows 10, Windows 8.1, and Windows Phone 8.1, so resolve to those if available, else 12
+        result = (availableVersions['15.0'] || availableVersions['14.0'] || availableVersions['12.0']);
     }
 
     return result;
@@ -525,6 +525,10 @@ function msBuild14TargetsFilter(target) {
     return target === projFiles.win || target === projFiles.phone || target === projFiles.win10;
 }
 
+function msBuild15TargetsFilter(target) {
+    return target === projFiles.win || target === projFiles.phone || target === projFiles.win10;
+}
+
 function filterSupportedTargets (targets, msbuild) {
     if (!targets || targets.length === 0) {
         events.emit('warn', 'No build targets are specified.');
@@ -534,7 +538,8 @@ function filterSupportedTargets (targets, msbuild) {
     var targetFilters = {
         '4.0': msBuild4TargetsFilter,
         '12.0': msBuild12TargetsFilter,
-        '14.0': msBuild14TargetsFilter
+        '14.0': msBuild14TargetsFilter,
+        '15.0': msBuild15TargetsFilter
     };
 
     var filter = targetFilters[msbuild.version];


### PR DESCRIPTION
Reference the JIRA issue for more explanation.

The targets filter for 15.0 is currently the same as 14.0, but I copied to a separate function for clarity and in case it ever changes while 15.0 is being developed further.