### PR TITLE
CB-10193 Add BOM to www files at build stage instead of prepare

### DIFF
--- a/spec/unit/build.spec.js
+++ b/spec/unit/build.spec.js
@@ -22,6 +22,7 @@ var Q = require('q'),
     platformRoot = '../../template',
     testPath = 'testpath',
     buildPath = path.join(platformRoot, 'cordova', 'build'),
+    prepare = require(platformRoot + '/cordova/lib/prepare.js'),
     build = rewire(platformRoot + '/cordova/lib/build.js');
 
 function createFindAvailableVersionMock(version, path, buildSpy) {
@@ -90,6 +91,14 @@ describe('run method', function() {
         findAvailableVersionOriginal = build.__get__('MSBuildTools.findAvailableVersion');
         applyPlatformConfigOriginal = build.__get__('prepare.applyPlatformConfig');
         configParserOriginal = build.__get__('ConfigParser');
+
+        var originalBuildMethod = build.run;
+        spyOn(build, 'run').andCallFake(function () {
+            // Bind original build to custom 'this' object to mock platform's locations property
+            return originalBuildMethod.apply({locations: {www: 'some/path'}}, arguments);
+        });
+
+        spyOn(prepare, 'addBOMSignature');
     });
 
     afterEach(function() {

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -51,6 +51,7 @@ var ROOT = path.resolve(__dirname, '../..');
 // See 'help' function for args list
 module.exports.run = function run (buildOptions) {
 
+    var that = this;
     ROOT = this.root || ROOT;
 
     if (!utils.isCordovaProject(this.root)){
@@ -63,6 +64,10 @@ module.exports.run = function run (buildOptions) {
     .then(function(msbuildTools) {
         // Apply build related configs
         prepare.updateBuildConfig(buildConfig);
+        // CB-5421 Add BOM to all html, js, css files
+        // to ensure app can pass Windows Store Certification
+        prepare.addBOMSignature(that.locations.www);
+
         if (buildConfig.publisherId) {
             updateManifestWithPublisher(msbuildTools, buildConfig);
         }

--- a/template/cordova/lib/prepare.js
+++ b/template/cordova/lib/prepare.js
@@ -416,8 +416,6 @@ module.exports.prepare = function (cordovaProject) {
     })
     .then(function () {
         copyImages(cordovaProject.projectConfig, self.root);
-        // CB-5421 Add BOM to all html, js, css files to ensure app can pass Windows Store Certification
-        addBOMSignature(self.locations.www);
     })
     .then(function () {
         self.events.emit('verbose', 'Updated project successfully');
@@ -450,6 +448,8 @@ function addBOMSignature(directory) {
         }
     });
 }
+
+module.exports.addBOMSignature = addBOMSignature;
 
 /**
  * Updates config files in project based on app's config.xml and config munge,


### PR DESCRIPTION
This PR moves adding BOM to JS files from prepare to build stage. This should fix the potential problem (as explained in [mailing list discussion](http://markmail.org/thread/cg5s2jvxvyyqcqpd)) when www files already contain BOM signatures at the time when 'after_prepare' hook ([or simulated 'pre_package' hook](https://github.com/apache/cordova-lib/commit/4478eaf0783a2f73962e5911a0c26cc4db1da241)) is fired.

JIRA issue: [CB-10193](https://issues.apache.org/jira/browse/CB-10193)