### PR TITLE
CB-10234 Better error message when Windows10 requires 'arch' flag

### DIFF
--- a/template/CordovaApp.Windows10.jsproj
+++ b/template/CordovaApp.Windows10.jsproj
@@ -102,15 +102,7 @@
   </ItemGroup>
   <Import Project="CordovaApp.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\$(WMSJSProjectDirectory)\Microsoft.VisualStudio.$(WMSJSProject).targets" />
-  <!-- To modify your build process, add your task inside one of the targets below then uncomment
-       that target and the DisableFastUpToDateCheck PropertyGroup.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  <PropertyGroup>
-    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
-  </PropertyGroup>
-  -->
+  <Target AfterTargets="ResolveAssemblyReferences" BeforeTargets="AfterResolveReferences" Condition="'$(Platform)' == 'AnyCPU'" Name="DetectMangedWinMDWithAnyCpu">
+    <Error Condition="'%(_ResolveAssemblyReferenceResolvedFiles.WinMDFile)' == 'true' AND '%(_ResolveAssemblyReferenceResolvedFiles.WinMDFileType)' == 'Managed'" Text="The following component requires .NET Native compilation which is not available when targeting 'Windows10' and 'AnyCPU'. Please consider changing the targeted processor architecture to one of the following: 'x86, x64, ARM' (if you are using command line this could be done by adding '--archs' parameter, for example: 'cordova build windows --archs=x64'). %(_ResolveAssemblyReferenceResolvedFiles.Identity)" />
+    </Target>
 </Project>


### PR DESCRIPTION
This patch adds the following error message:
![image](https://cloud.githubusercontent.com/assets/981580/12324140/b9551428-bad1-11e5-9acd-d5edb6834987.png)

Original message is showed below:
![image](https://cloud.githubusercontent.com/assets/981580/12324182/f82be226-bad1-11e5-9578-32d7bf5ffb19.png)
