### PR TITLE
don't copy resource-files at plugin install

### DIFF
--- a/template/cordova/lib/JsprojManager.js
+++ b/template/cordova/lib/JsprojManager.js
@@ -108,19 +108,19 @@ jsprojManager.prototype = {
         });
     },
 
-    addResourceFileToProject: function (relPath, targetConditions) {
-        events.emit('verbose', 'jsprojManager.addResourceFile(relPath: ' + relPath + ', targetConditions: ' + JSON.stringify(targetConditions) + ')');
+    addResourceFileToProject: function (sourcePath, destPath, targetConditions) {
+        events.emit('verbose', 'jsprojManager.addResourceFile(sourcePath: ' + sourcePath + ', destPath: ' + destPath + ', targetConditions: ' + JSON.stringify(targetConditions) + ')');
 
         // add hint path with full path
         var link = new et.Element('Link');
-        link.text = relPath;
+        link.text = destPath;
         var children = [link];
 
         var copyToOutputDirectory = new et.Element('CopyToOutputDirectory');
         copyToOutputDirectory.text = 'Always';
         children.push(copyToOutputDirectory);
 
-        var item = createItemGroupElement('ItemGroup/Content', relPath, targetConditions, children);
+        var item = createItemGroupElement('ItemGroup/Content', sourcePath, targetConditions, children);
         this._getMatchingProjects(targetConditions).forEach(function (project) {
             project.appendToRoot(item);
         });
@@ -128,7 +128,6 @@ jsprojManager.prototype = {
 
     removeResourceFileFromProject: function (relPath, targetConditions) {
         events.emit('verbose', 'jsprojManager.removeResourceFile(relPath: ' + relPath + ', targetConditions: ' + JSON.stringify(targetConditions) + ')');
-
         this._getMatchingProjects(targetConditions).forEach(function (project) {
             project.removeItemGroupElement('ItemGroup/Content', relPath, targetConditions);
         });

--- a/template/cordova/lib/PluginHandler.js
+++ b/template/cordova/lib/PluginHandler.js
@@ -25,6 +25,13 @@ var shell = require('shelljs');
 var events = require('cordova-common').events;
 var CordovaError = require('cordova-common').CordovaError;
 
+// returns relative file path for a file in the plugin's folder that can be referenced 
+// from a project file. 
+function getPluginFilePath(plugin, pluginFile, targetDir) {
+    var src = path.resolve(plugin.dir, pluginFile);
+    return '$(ProjectDir)' + path.relative(targetDir, src);
+}
+
 var handlers = {
     'source-file': {
         install:function(obj, plugin, project, options) {
@@ -50,11 +57,12 @@ var handlers = {
             // <resource-file src="$(Platform)/My.dll" target="My.dll" />
 
             var src = path.resolve(plugin.dir, obj.src);
-            project.addResourceFileToProject(src, obj.target, getTargetConditions(obj));
+            var relativeSrcPath = getPluginFilePath(plugin, obj.src, project.projectFolder);
+            project.addResourceFileToProject(relativeSrcPath, obj.target, getTargetConditions(obj));
         },
         uninstall:function(obj, plugin, project, options) {
-            var src = path.resolve(plugin.dir, obj.src);
-            project.removeResourceFileFromProject(src, getTargetConditions(obj));
+            var relativeSrcPath = getPluginFilePath(plugin, obj.src, project.projectFolder);
+            project.removeResourceFileFromProject(relativeSrcPath, getTargetConditions(obj));
         }
     },
     'lib-file': {

--- a/template/cordova/lib/PluginHandler.js
+++ b/template/cordova/lib/PluginHandler.js
@@ -42,13 +42,20 @@ var handlers = {
     },
     'resource-file':{
         install:function(obj, plugin, project, options) {
-            // as per specification resource-file target is specified relative to platform root
-            copyFile(plugin.dir, obj.src, project.root, obj.target);
-            project.addResourceFileToProject(obj.target, getTargetConditions(obj));
+            // do not copy, but reference the file in the plugin folder. This allows to 
+            // have multiple source files map to the same target and select the appropriate
+            // one based on the current build settings, e.g. architecture.
+            // also, we don't check for existence. This allows to insert build variables 
+            // into the source file name, e.g.
+            // <resource-file src="$(Platform)/My.dll" target="My.dll" />
+
+            var src = path.resolve(plugin.dir, obj.src);
+            console.log(src);
+            project.addResourceFileToProject(src, obj.target, getTargetConditions(obj));
         },
         uninstall:function(obj, plugin, project, options) {
-            removeFile(project.root, obj.target);
-            project.removeResourceFileFromProject(obj.target, getTargetConditions(obj));
+            var src = path.resolve(plugin.dir, obj.src);
+            project.removeResourceFileFromProject(src, getTargetConditions(obj));
         }
     },
     'lib-file': {

--- a/template/cordova/lib/PluginHandler.js
+++ b/template/cordova/lib/PluginHandler.js
@@ -55,8 +55,6 @@ var handlers = {
             // also, we don't check for existence. This allows to insert build variables 
             // into the source file name, e.g.
             // <resource-file src="$(Platform)/My.dll" target="My.dll" />
-
-            var src = path.resolve(plugin.dir, obj.src);
             var relativeSrcPath = getPluginFilePath(plugin, obj.src, project.projectFolder);
             project.addResourceFileToProject(relativeSrcPath, obj.target, getTargetConditions(obj));
         },

--- a/template/cordova/lib/PluginHandler.js
+++ b/template/cordova/lib/PluginHandler.js
@@ -50,7 +50,6 @@ var handlers = {
             // <resource-file src="$(Platform)/My.dll" target="My.dll" />
 
             var src = path.resolve(plugin.dir, obj.src);
-            console.log(src);
             project.addResourceFileToProject(src, obj.target, getTargetConditions(obj));
         },
         uninstall:function(obj, plugin, project, options) {


### PR DESCRIPTION
Instead, reference the file in the plugin directory. This allows to have multiple
source files map to the same destination file inside the build directory and
choose the appropriate file based on the build configuration, e.g. architecture.

This implements a fix for CB-10326