### PR TITLE
CB-10381 fix the bug when removing a plugin with a <framework> tag

### DIFF
--- a/template/cordova/lib/PluginHandler.js
+++ b/template/cordova/lib/PluginHandler.js
@@ -89,7 +89,7 @@ var handlers = {
             var type = obj.type;
 
             if(type === 'projectReference') {
-                project.removeProjectReference(plugin.dir, getTargetConditions(obj));
+                project.removeProjectReference(path.join(plugin.dir, src), getTargetConditions(obj));
             }
             else {
                 var targetPath = path.join('plugins', plugin.id);


### PR DESCRIPTION
I fixed a simple bug that caused an exception EISDIR when removing a plugin that includes a <frame> tag.
PluginHandler.js should have passed the project file instead of the plugin directory.