### PR TITLE
CB-10714 Ignore case for --archs

### DIFF
--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -181,7 +181,7 @@ function parseAndValidateArgs(options) {
     // get build options/defaults
     config.buildType = options.release ? 'release' : 'debug';
 
-    var archs = options.archs || args.archs;
+    var archs = options.archs || args.archs.toLowerCase();
     config.buildArchs = archs ? archs.split(' ') : ['anycpu'];
 
     config.phone = args.phone ? true : false;


### PR DESCRIPTION
If "ARM" is passed to --archs, the Appx file is compiled, but the build
will fail due to a case sensitive string comparison.