### PR TITLE
CB-10673 fixed conflicting plugin install issue with overlapped <source-tag>

### DIFF
--- a/template/cordova/lib/PluginHandler.js
+++ b/template/cordova/lib/PluginHandler.js
@@ -36,7 +36,7 @@ var handlers = {
     'source-file': {
         install:function(obj, plugin, project, options) {
             var dest = path.join('plugins', plugin.id, obj.targetDir || '', path.basename(obj.src));
-            if (options && options.forceCopyingSrc) {
+            if (options && options.force) {
                 copyFile(plugin.dir, obj.src, project.root, dest);
             } else {
                 copyNewFile(plugin.dir, obj.src, project.root, dest);

--- a/template/cordova/lib/PluginHandler.js
+++ b/template/cordova/lib/PluginHandler.js
@@ -36,7 +36,7 @@ var handlers = {
     'source-file': {
         install:function(obj, plugin, project, options) {
             var dest = path.join('plugins', plugin.id, obj.targetDir || '', path.basename(obj.src));
-            copyNewFile(plugin.dir, obj.src, project.root, dest);
+            copyFile(plugin.dir, obj.src, project.root, dest);
             // add reference to this file to jsproj.
             project.addSourceFile(dest);
         },

--- a/template/cordova/lib/PluginHandler.js
+++ b/template/cordova/lib/PluginHandler.js
@@ -207,7 +207,7 @@ function copyFile (plugin_dir, src, project_dir, dest, link) {
         shell.cp('-f', src, dest);
     }
 }
-
+/*
 // Same as copy file but throws error if target exists
 function copyNewFile (plugin_dir, src, project_dir, dest, link) {
     var target_path = path.resolve(project_dir, dest);
@@ -216,7 +216,7 @@ function copyNewFile (plugin_dir, src, project_dir, dest, link) {
 
     copyFile(plugin_dir, src, project_dir, dest, !!link);
 }
-
+*/
 // checks if file exists and then deletes. Error if doesn't exist
 function removeFile (project_dir, src) {
     var file = path.resolve(project_dir, src);

--- a/template/cordova/lib/PluginHandler.js
+++ b/template/cordova/lib/PluginHandler.js
@@ -36,7 +36,11 @@ var handlers = {
     'source-file': {
         install:function(obj, plugin, project, options) {
             var dest = path.join('plugins', plugin.id, obj.targetDir || '', path.basename(obj.src));
-            copyFile(plugin.dir, obj.src, project.root, dest);
+            if (options && options.forceCopyingSrc) {
+                copyFile(plugin.dir, obj.src, project.root, dest);
+            } else {
+                copyNewFile(plugin.dir, obj.src, project.root, dest);
+            }
             // add reference to this file to jsproj.
             project.addSourceFile(dest);
         },
@@ -207,7 +211,7 @@ function copyFile (plugin_dir, src, project_dir, dest, link) {
         shell.cp('-f', src, dest);
     }
 }
-/*
+
 // Same as copy file but throws error if target exists
 function copyNewFile (plugin_dir, src, project_dir, dest, link) {
     var target_path = path.resolve(project_dir, dest);
@@ -216,7 +220,7 @@ function copyNewFile (plugin_dir, src, project_dir, dest, link) {
 
     copyFile(plugin_dir, src, project_dir, dest, !!link);
 }
-*/
+
 // checks if file exists and then deletes. Error if doesn't exist
 function removeFile (project_dir, src) {
     var file = path.resolve(project_dir, src);


### PR DESCRIPTION
The problem is that copyNewFile is too strict for <source-file> tag.
You will never know which two plugins will write the library to the same target-dir of the source-file.
We should let it copy the library to the same location.