### PR TITLE
CB-10622 Fix targetsize images being ignored

### DIFF
--- a/node_modules/cordova-common/src/ConfigParser/ConfigParser.js
+++ b/node_modules/cordova-common/src/ConfigParser/ConfigParser.js
@@ -187,6 +187,7 @@ ConfigParser.prototype = {
             var res = {};
             res.src = elt.attrib.src;
             res.density = elt.attrib['density'] || elt.attrib[that.cdvNamespacePrefix+':density'] || elt.attrib['gap:density'];
+            res.target = elt.attrib['target'];
             res.platform = elt.platform || null; // null means icon represents default icon (shared between platforms)
             res.width = +elt.attrib.width || undefined;
             res.height = +elt.attrib.height || undefined;


### PR DESCRIPTION
In the icon tag in config.xml the icon-"target" attribute is not read, so MRT images are not loaded at all

e.g.
 <icon src="build/windows/storelogo.jpg" target="storelogo" />