### PR TITLE
CB-11024: Add preference to set the min UAP target version in the JSP…

### DIFF
--- a/template/cordova/lib/ConfigParser.js
+++ b/template/cordova/lib/ConfigParser.js
@@ -73,6 +73,16 @@ WindowsConfigParser.prototype.getWindowsTargetVersion = function() {
     return preference;
 };
 
+WindowsConfigParser.prototype.getUAPTargetMinVersion = function() {
+    var preference = this.getPreference('uap-target-min-version');
+
+    if (!preference) {
+        preference = '10.0.10240.0'; // set default to 10.0.10240.0 (initial release)
+    }
+
+    return preference;
+};
+
 WindowsConfigParser.prototype.getWindowsPhoneTargetVersion = function() {
     // This is a little more complicated than the previous one.
     // 1. Check for an explicit preference.  If the preference is set explicitly, return that, irrespective of whether it is valid

--- a/template/cordova/lib/prepare.js
+++ b/template/cordova/lib/prepare.js
@@ -393,7 +393,7 @@ function applyUAPVersionToProject(projectFilePath, uapVersionInfo) {
 }
 
 // returns {minUAPVersion: Version, targetUAPVersion: Version} | false
-function getUAPVersions() {
+function getUAPVersions(config) {
     var baselineVersions = MSBuildTools.getAvailableUAPVersions();
     if (!baselineVersions || baselineVersions.length === 0) {
         return false;
@@ -401,9 +401,11 @@ function getUAPVersions() {
 
     baselineVersions.sort(Version.comparer);
 
+    var uapTargetMinPreference = config.getUAPTargetMinVersion();
+
     return {
-        minUAPVersion: baselineVersions[0],
-        targetUAPVersion: baselineVersions[baselineVersions.length - 1]
+        minUAPVersion: uapTargetMinPreference,
+        targetUAPVersion: baselineVersions[baselineVersions.length - 1] /* The highest available SDK on the system */
     };
 }
 
@@ -551,6 +553,6 @@ function updateProjectAccordingTo(projectConfig, locations) {
     });
 
     if (process.platform === 'win32') {
-        applyUAPVersionToProject(path.join(locations.root, PROJECT_WINDOWS10), getUAPVersions());
+        applyUAPVersionToProject(path.join(locations.root, PROJECT_WINDOWS10), getUAPVersions(projectConfig));
     }
 }


### PR DESCRIPTION
…roj File

The current preferences allow the user to set the target and min versions in the appxmanifest files. The  target min version in the jsproj file currently is set to be the minimum SDK installed on the user machine. This change allows the user to change it using this new preference else defaults it to '10.0.10240.0' 