### PR TITLE
CB-11066 Remove uap prefixed capabilities when plugin has added regular ones

### DIFF
--- a/spec/unit/ConfigChanges.spec.js
+++ b/spec/unit/ConfigChanges.spec.js
@@ -1,0 +1,77 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var BaseMunger = require('cordova-common').ConfigChanges.PlatformMunger;
+var PlatformMunger = require('../../template/cordova/lib/ConfigChanges').PlatformMunger;
+
+var os = require('os');
+var path = require('path');
+var shell = require('shelljs');
+
+var tempDir = path.join(os.tmpdir(), 'windows');
+var WINDOWS_MANIFEST = 'package.windows.appxmanifest';
+var WINDOWS10_MANIFEST = 'package.windows10.appxmanifest';
+
+describe('PlatformMunger', function () {
+    var munge, munger;
+
+    beforeEach(function () {
+        shell.mkdir('-p', tempDir);
+        munge = { parents: { 'foo/bar': [
+            { before: undefined, count: 1, xml: '<DummyElement name="Dummy" />'}
+        ]}};
+        munger = new PlatformMunger('windows', tempDir);
+        spyOn(BaseMunger.prototype, 'apply_file_munge').andCallThrough();
+    });
+
+    afterEach(function () {
+        shell.rm('-rf', tempDir);
+    });
+
+    describe('apply_file_munge method', function () {
+
+        it('should call parent\'s method with the same parameters', function () {
+            munger.apply_file_munge(WINDOWS_MANIFEST, munge, false);
+            expect(BaseMunger.prototype.apply_file_munge).toHaveBeenCalledWith(WINDOWS_MANIFEST, munge, false);
+        });
+
+        it('should additionally call parent\'s method with another munge if removing changes from windows 10 appxmanifest', function () {
+            munger.apply_file_munge('package.windows10.appxmanifest', munge, /*remove=*/true);
+            expect(BaseMunger.prototype.apply_file_munge).toHaveBeenCalledWith(WINDOWS10_MANIFEST, munge, true);
+            expect(BaseMunger.prototype.apply_file_munge).toHaveBeenCalledWith(WINDOWS10_MANIFEST, jasmine.any(Object), true);
+        });
+
+        it('should remove uap: capabilities added by windows prepare step', function () {
+            // Generate a munge that contain non-prefixed capabilities changes
+            var baseMunge = { parents: { WINDOWS10_MANIFEST: [
+                // Emulate capability that was initially added with uap prefix
+                { before: undefined, count: 1, xml: '<uap:Capability Name=\"privateNetworkClientServer\">'},
+                { before: undefined, count: 1, xml: '<Capability Name=\"enterpriseAuthentication\">'}
+            ]}};
+
+            var capabilitiesMunge = { parents: { WINDOWS10_MANIFEST: [
+                { before: undefined, count: 1, xml: '<uap:Capability Name=\"enterpriseAuthentication\">'}
+            ]}};
+
+            munger.apply_file_munge('package.windows10.appxmanifest', baseMunge, /*remove=*/true);
+            expect(BaseMunger.prototype.apply_file_munge).toHaveBeenCalledWith(WINDOWS10_MANIFEST, capabilitiesMunge, true);
+        });
+    });
+});
+

--- a/template/cordova/Api.js
+++ b/template/cordova/Api.js
@@ -29,7 +29,7 @@ var ActionStack = require('cordova-common').ActionStack;
 var CordovaError = require('cordova-common').CordovaError;
 var CordovaLogger = require('cordova-common').CordovaLogger;
 var PlatformJson = require('cordova-common').PlatformJson;
-var PlatformMunger = require('cordova-common').ConfigChanges.PlatformMunger;
+var PlatformMunger = require('./lib/ConfigChanges').PlatformMunger;
 var PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 
 var PLATFORM = 'windows';

--- a/template/cordova/lib/ConfigChanges.js
+++ b/template/cordova/lib/ConfigChanges.js
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var util = require('util');
+var CommonMunger = require('cordova-common').ConfigChanges.PlatformMunger;
+
+function PlatformMunger(platform, project_dir, platformJson, pluginInfoProvider) {
+    CommonMunger.apply(this, arguments);
+}
+
+util.inherits(PlatformMunger, CommonMunger);
+
+/**
+ * This is an override of apply_file_munge method from cordova-common's PlatformMunger class.
+ * In addition to parent's method logic also removes capabilities with 'uap:' prefix that were
+ * added by AppxManifest class
+ *
+ * @param {String}  file   A file name to apply munge to
+ * @param {Object}  munge  Serialized changes that need to be applied to the file
+ * @param {Boolean} [remove=false] Flag that specifies whether the changes
+ *   need to be removed or added to the file
+ */
+PlatformMunger.prototype.apply_file_munge = function (file, munge, remove) {
+    // Call parent class' method
+    PlatformMunger.super_.prototype.apply_file_munge.call(this, file, munge, remove);
+
+    // CB-11066 If this is a windows10 manifest and we're removing the changes
+    // then we also need to check if there are <Capability> elements were previously
+    // added and schedule removal of corresponding <uap:Capability> elements
+    if (remove && file === 'package.windows10.appxmanifest') {
+        var uapCapabilitiesMunge = generateUapCapabilities(munge);
+        // We do not check whether generated munge is empty or not before calling
+        // 'apply_file_munge' since applying empty one is just a no-op
+        PlatformMunger.super_.prototype.apply_file_munge.call(this, file, uapCapabilitiesMunge, remove);
+    }
+};
+
+/**
+ * Generates a new munge that contains <uap:Capability> elements created based on
+ * corresponding <Capability> elements from base munge. If there are no such elements
+ * found in base munge, the empty munge is returned (selectors might be present under
+ * the 'parents' key, but they will contain no changes).
+ *
+ * @param {Object} munge A munge that we need to check for <Capability> elements
+ * @return {Object} A munge with 'uap'-prefixed capabilities or empty one
+ */
+function generateUapCapabilities(munge) {
+
+    function hasCapabilityChange(change) {
+        return /^\s*<Capability\s/.test(change.xml);
+    }
+
+    function createPrefixedCapabilityChange(change) {
+        return {
+            xml: change.xml.replace(/Capability/, 'uap:Capability'),
+            count: change.count,
+            before: change.before
+        };
+    }
+
+    // Iterate through all selectors in munge
+    return Object.keys(munge.parents)
+    .reduce(function (result, selector) {
+        result.parents[selector] = munge.parents[selector]
+        // For every xml change check if it adds a <Capability> element ...
+        .filter(hasCapabilityChange)
+        // ... and create a duplicate with 'uap:' prefix
+        .map(createPrefixedCapabilityChange);
+
+        return result;
+    }, { parents: {} });
+}
+
+exports.PlatformMunger = PlatformMunger;


### PR DESCRIPTION
This fixes a problem when some of capabilities, added by plugin are being modified at 'prepare' stage due to special Windows logic and then aren't removed when uninstalling plugin. For details see [CB-11066](https://issues.apache.org/jira/browse/CB-11066)