### PR TITLE
CB-11516 windows: Preparing icons w/ target fails

### DIFF
--- a/spec/unit/Prepare.Win10.spec.js
+++ b/spec/unit/Prepare.Win10.spec.js
@@ -507,16 +507,16 @@ describe('copyIcons method', function () {
     describe('when "target" attribute is specified for the image', function () {
         it('should copy all images with the same base name and extension to destination dir', function () {
             var matchingFiles = [
-                'res/Windows/Square44x44.scale-100.png',
-                'res/Windows/Square44x44.targetsize-16.png',
-                'res/Windows/Square44x44.scale-150_targetsize-16.png',
-                'res/Windows/Square44x44.targetsize-16_scale-200.png',
-                'res/Windows/Square44x44.targetsize-16_altform-unplated_scale-200.png'
+                'Square44x44.scale-100.png',
+                'Square44x44.targetsize-16.png',
+                'Square44x44.scale-150_targetsize-16.png',
+                'Square44x44.targetsize-16_scale-200.png',
+                'Square44x44.targetsize-16_altform-unplated_scale-200.png'
             ];
 
             var nonMatchingFiles = [
-                'res/Windows/Square55x55.scale-100.png',
-                'res/Windows/Square44x44.targetsize-16.jpg'
+                'Square55x55.scale-100.png',
+                'Square44x44.targetsize-16.jpg'
             ];
 
             spyOn(fs, 'readdirSync').andReturn(matchingFiles.concat(nonMatchingFiles));
@@ -528,16 +528,16 @@ describe('copyIcons method', function () {
             copyImages(project, locations);
 
             var expectedPathMap = {};
-            expectedPathMap['images' + path.sep + 'SmallIcon.scale-100.png'] =
-                    'res/Windows/Square44x44.scale-100.png';
-            expectedPathMap['images' + path.sep + 'SmallIcon.targetsize-16.png'] =
-                    'res/Windows/Square44x44.targetsize-16.png';
-            expectedPathMap['images' + path.sep + 'SmallIcon.scale-150_targetsize-16.png'] =
-                    'res/Windows/Square44x44.scale-150_targetsize-16.png';
-            expectedPathMap['images' + path.sep + 'SmallIcon.targetsize-16_scale-200.png'] =
-                    'res/Windows/Square44x44.targetsize-16_scale-200.png';
-            expectedPathMap['images' + path.sep + 'SmallIcon.targetsize-16_altform-unplated_scale-200.png'] =
-                    'res/Windows/Square44x44.targetsize-16_altform-unplated_scale-200.png';
+            expectedPathMap[path.join('images', 'SmallIcon.scale-100.png')] =
+                    path.join('res', 'Windows', 'Square44x44.scale-100.png');
+            expectedPathMap[path.join('images','SmallIcon.targetsize-16.png')] =
+                    path.join('res', 'Windows', 'Square44x44.targetsize-16.png');
+            expectedPathMap[path.join('images', 'SmallIcon.scale-150_targetsize-16.png')] =
+                    path.join('res', 'Windows', 'Square44x44.scale-150_targetsize-16.png');
+            expectedPathMap[path.join('images', 'SmallIcon.targetsize-16_scale-200.png')] =
+                    path.join('res', 'Windows', 'Square44x44.targetsize-16_scale-200.png');
+            expectedPathMap[path.join('images', 'SmallIcon.targetsize-16_altform-unplated_scale-200.png')] =
+                    path.join('res', 'Windows', 'Square44x44.targetsize-16_altform-unplated_scale-200.png');
             expect(FileUpdater.updatePaths).toHaveBeenCalledWith(expectedPathMap, { rootDir: PROJECT }, logFileOp);
         });
     });

--- a/template/cordova/lib/prepare.js
+++ b/template/cordova/lib/prepare.js
@@ -344,7 +344,7 @@ function mapImageResources(images, imagesDir) {
 
             // then get all matching MRT images in source directory
             var candidates = fs.readdirSync(imageToCopy.location)
-            .map(function (file) { return new MRTImage(file); })
+            .map(function (file) { return new MRTImage(path.join(imageToCopy.location, file)); })
             .filter(imageToCopy.matchesTo, imageToCopy);
 
             // Warn user if no images were copied


### PR DESCRIPTION
Putting the following line in the config will will cause an error: "Source
directory does not exist: Square44x44Logo_100.scale"
<icon src="res/Windows/Square44x44Logo_100.png" target="SmallIcon"/>
In prepare.js, `copyImages` calls `mapImageResources` but subdirectory
information was lost. `copyMrtImage` in an earlier commit preserved this
information (shown in the link below), but it was lost in a refactoring.
https://github.com/apache/cordova-windows/blob/c1b80be51cdbd90160b6cb8162350bced8e1c44b/template/cordova/lib/prepare.js#L316
This was missed by a defect in the `copyIcons` test in
Prepare.Win10.spec.js:
`readdirSync` was spied on to return an array of file paths when it
actually only returns an array of the filenames. This caused the
`copyIcons` spec to pass but the code failed when used.