### PR TITLE
CB-11558 Make windows plugin rm remove ProjectReference items

### DIFF
--- a/spec/unit/pluginHandler/windows.spec.js
+++ b/spec/unit/pluginHandler/windows.spec.js
@@ -65,7 +65,8 @@ beforeEach(function () {
             };
 
             return xml.find(xpath) !== null;
-        }    });
+        }
+    });
 });
 
 var getPluginFilePath = PluginHandler.__get__('getPluginFilePath');
@@ -88,6 +89,10 @@ describe('windows project handler', function () {
         shell.cp('-rf', path.join(__dirname, '../fixtures/DummyProject/*'), cordovaProjectWindowsPlatformDir);
         dummyProject = JsprojManager.getProject(cordovaProjectWindowsPlatformDir);
         shell.mkdir('-p', cordovaProjectPluginsDir);
+        shell.cp('-rf', dummyplugin, cordovaProjectPluginsDir);
+        // CB-11558 Reinitialize plugin.dir to become project_root/plugins/plugin.id to avoid 
+        // different drives issue resulting in absolute path in projectReferences.
+        dummyPluginInfo = new PluginInfo(path.join(cordovaProjectPluginsDir, dummyPluginInfo.id));
     });
 
     afterEach(function () {
@@ -182,7 +187,7 @@ describe('windows project handler', function () {
             it('should copy stuff from one location to another by calling common.copyFile', function () {
                 var source = copyArray(valid_source);
                 install(source[0], dummyPluginInfo, dummyProject);
-                expect(copyFileSpy).toHaveBeenCalledWith(dummyplugin, 'src/windows/dummer.js', cordovaProjectWindowsPlatformDir, path.join('plugins', 'org.test.plugins.dummyplugin', 'dummer.js'), false);
+                expect(copyFileSpy).toHaveBeenCalledWith(dummyPluginInfo.dir, 'src/windows/dummer.js', cordovaProjectWindowsPlatformDir, path.join('plugins', 'org.test.plugins.dummyplugin', 'dummer.js'), false);
             });
             it('should throw if source-file src cannot be found', function () {
                 var source = copyArray(invalid_source);
@@ -556,19 +561,19 @@ describe('windows project handler', function () {
                 });
 
                 var xmlPath = 'ItemGroup/ProjectReference';
-                var incText = winJoin(dummyPluginInfo.dir, frameworks[6].src);
+                var incText = winJoin('..', '..', 'plugins', dummyPluginInfo.id, frameworks[6].src);
                 var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x64'};
                 validateUninstalledProjects('framework', frameworks[6], xmlPath, incText, targetConditions, ['all']);
 
-                incText = winJoin(dummyPluginInfo.dir, frameworks[7].src);
+                incText = winJoin('..', '..', 'plugins', dummyPluginInfo.id, frameworks[7].src);
                 targetConditions = {versions: '<8.1', deviceTarget: undefined, arch: undefined};
                 validateUninstalledProjects('framework', frameworks[7], xmlPath, incText, targetConditions, ['windows8']);
 
-                incText = winJoin(dummyPluginInfo.dir, frameworks[8].src);
+                incText = winJoin('..', '..', 'plugins', dummyPluginInfo.id, frameworks[8].src);
                 targetConditions = {versions: undefined, deviceTarget: 'win', arch: undefined};
                 validateUninstalledProjects('framework', frameworks[8], xmlPath, incText, targetConditions, ['windows', 'windows8', 'windows10']);
 
-                incText = winJoin(dummyPluginInfo.dir, frameworks[9].src);
+                incText = winJoin('..', '..', 'plugins', dummyPluginInfo.id, frameworks[9].src);
                 targetConditions = {versions: '8.1', deviceTarget: 'all', arch: 'x86'};
                 validateUninstalledProjects('framework', frameworks[9], xmlPath, incText, targetConditions, ['windows', 'phone']);
 

--- a/template/cordova/lib/JsprojManager.js
+++ b/template/cordova/lib/JsprojManager.js
@@ -182,9 +182,9 @@ jsprojManager.prototype = {
         // relative_path is the actual path to the file in the current OS, where-as inserted_path is what we write in
         // the project file, and is always in Windows format.
         relative_path = path.normalize(relative_path);
-        var inserted_path = path.join('..', '..', relative_path).split('/').join('\\');
+        var inserted_path = relative_path.split('/').join('\\');
 
-        var pluginProjectXML = xml_helpers.parseElementtreeSync(relative_path);
+        var pluginProjectXML = xml_helpers.parseElementtreeSync(path.resolve(this.projectFolder, relative_path));
 
         // find the guid + name of the referenced project
         var projectGuid = pluginProjectXML.find("PropertyGroup/ProjectGuid").text;
@@ -265,7 +265,7 @@ jsprojManager.prototype = {
         var inserted_path = relative_path.split('/').join('\\');
 
         // find the guid + name of the referenced project
-        var pluginProjectXML = xml_helpers.parseElementtreeSync(relative_path);
+        var pluginProjectXML = xml_helpers.parseElementtreeSync(path.resolve(this.projectFolder, relative_path));
         var projectGuid = pluginProjectXML.find("PropertyGroup/ProjectGuid").text;
         var projName = getProjectName(pluginProjectXML, relative_path);
 

--- a/template/cordova/lib/PluginHandler.js
+++ b/template/cordova/lib/PluginHandler.js
@@ -88,7 +88,7 @@ var handlers = {
             var targetDir = obj.targetDir || '';
 
             if(type === 'projectReference') {
-                dest = path.join('plugins', plugin.id, targetDir, src);
+                dest = path.join(path.relative(project.projectFolder, plugin.dir), targetDir, src);
                 project.addProjectReference(dest, getTargetConditions(obj));
             } else {
                 // path.join ignores empty paths passed so we don't check whether targetDir is not empty
@@ -105,7 +105,7 @@ var handlers = {
             var type = obj.type;
 
             if(type === 'projectReference') {
-                project.removeProjectReference(path.join(plugin.dir, src), getTargetConditions(obj));
+                project.removeProjectReference(path.join(path.relative(project.projectFolder, plugin.dir), src), getTargetConditions(obj));
             }
             else {
                 var targetPath = path.join('plugins', plugin.id);


### PR DESCRIPTION
The issue was that we have been passing a relative path during `JsprojManager`.`addProjectReference` and an absolute path during `JsprojManager`.`removeProjectReference` so that regexp failed to find and remove it.
The tests were passing as they were also using absolute paths to the dummy plugin (it was not being added to the test project at all).

Initial idea was to use relative paths instead for project sharing: [CB-10927 Framework references in plugin.xml file prevent Windows Universal projects from being used on other machines](https://issues.apache.org/jira/browse/CB-10927)

Also updated the tests to use relative paths to the ProjectReferences.

[Jira issue](https://issues.apache.org/jira/browse/CB-11558)