### PR TITLE
Fix duplicate capability declarations in Win10 AppxManifest

### DIFF
--- a/spec/unit/AppxManifest.spec.js
+++ b/spec/unit/AppxManifest.spec.js
@@ -25,6 +25,7 @@ var Win10AppxManifest = AppxManifest.__get__('Win10AppxManifest');
 var refineColor = AppxManifest.__get__('refineColor');
 
 var WINDOWS_MANIFEST = 'template/package.windows.appxmanifest';
+var WINDOWS_10_MANIFEST = 'template/package.windows10.appxmanifest';
 var WINDOWS_PHONE_MANIFEST = 'template/package.phone.appxmanifest';
 var CSS_COLOR_NAME = 'turquoise';
 
@@ -166,6 +167,19 @@ describe('AppxManifest', function () {
                 expect(function () { emptyManifest[method](); }).toThrow();
                 expect(manifest[method]()).toBeDefined();
             });
+        });
+    });
+
+    describe('instance write method', function () {
+        it('should not write duplicate UAP capability declarations', function () {
+            var manifest = AppxManifest.get(WINDOWS_10_MANIFEST);
+            var capabilities = manifest.doc.find('.//Capabilities');
+            capabilities.append(new et.Element('uap:Capability', { 'Name': 'enterpriseAuthentication' }));
+            capabilities.append(new et.Element('uap:Capability', { 'Name': 'enterpriseAuthentication' }));
+            
+            var xml = manifest.writeToString();
+
+            expect((xml.match(/enterpriseAuthentication/g) || []).length).toBe(1);
         });
     });
 

--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -680,8 +680,8 @@ function ensureUapPrefixedCapabilities(capabilities) {
  */
 function ensureUniqueCapabilities(capabilities) {
     function isDuplicateCapability(value, index, self) { 
-        return self.findIndex(function(capability) { return capability.attrib.Name === value.attrib.Name }) !== index;
-    };
+        return self.findIndex(function(capability) { return capability.attrib.Name === value.attrib.Name; }) !== index;
+    }
 
     capabilities.getchildren().filter(isDuplicateCapability).forEach(function(value) {
         capabilities.remove(value);

--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -655,6 +655,7 @@ Win10AppxManifest.prototype.setDependencies = function (dependencies) {
  */
 Win10AppxManifest.prototype.write = function(destPath) {
     ensureUapPrefixedCapabilities(this.doc.find('.//Capabilities'));
+    ensureUniqueCapabilities(this.doc.find('.//Capabilities'));
     // sort Capability elements as per CB-5350 Windows8 build fails due to invalid 'Capabilities' definition
     sortCapabilities(this.doc);
     fs.writeFileSync(destPath || this.path, this.doc.write({indent: 4}), 'utf-8');
@@ -670,6 +671,20 @@ function ensureUapPrefixedCapabilities(capabilities) {
         if (CAPS_NEEDING_UAPNS.indexOf(el.attrib.Name) > -1 && el.tag.indexOf('uap:') !== 0) {
             el.tag = 'uap:' + el.tag;
         }
+    });
+}
+
+/**
+ * Cleans up duplicate capability declarations that were generated during the prepare process
+ * @param capabilities {ElementTree.Element} The appx manifest element for <capabilities>
+ */
+function ensureUniqueCapabilities(capabilities) {
+    function isDuplicateCapability(value, index, self) { 
+        return self.findIndex(function(capability) { return capability.attrib.Name === value.attrib.Name }) !== index;
+    };
+
+    capabilities.getchildren().filter(isDuplicateCapability).forEach(function(value) {
+        capabilities.remove(value);
     });
 }
 

--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -654,11 +654,15 @@ Win10AppxManifest.prototype.setDependencies = function (dependencies) {
  *   manifest will be written to file it has been read from.
  */
 Win10AppxManifest.prototype.write = function(destPath) {
+    fs.writeFileSync(destPath || this.path, this.writeToString(), 'utf-8');
+};
+
+Win10AppxManifest.prototype.writeToString = function() {
     ensureUapPrefixedCapabilities(this.doc.find('.//Capabilities'));
     ensureUniqueCapabilities(this.doc.find('.//Capabilities'));
     // sort Capability elements as per CB-5350 Windows8 build fails due to invalid 'Capabilities' definition
     sortCapabilities(this.doc);
-    fs.writeFileSync(destPath || this.path, this.doc.write({indent: 4}), 'utf-8');
+    return this.doc.write({indent: 4});
 };
 
 /**
@@ -679,12 +683,15 @@ function ensureUapPrefixedCapabilities(capabilities) {
  * @param capabilities {ElementTree.Element} The appx manifest element for <capabilities>
  */
 function ensureUniqueCapabilities(capabilities) {
-    function isDuplicateCapability(value, index, self) { 
-        return self.findIndex(function(capability) { return capability.attrib.Name === value.attrib.Name; }) !== index;
-    }
-
-    capabilities.getchildren().filter(isDuplicateCapability).forEach(function(value) {
-        capabilities.remove(value);
+    var uniqueCapabilities = [];
+    capabilities.getchildren()
+    .forEach(function(el) {
+        var name = el.attrib.Name;
+        if (uniqueCapabilities.indexOf(name) !== -1) {
+            capabilities.remove(el);
+        } else {
+            uniqueCapabilities.push(name);
+        }
     });
 }
 


### PR DESCRIPTION
I have created an issue for this in Jira: https://issues.apache.org/jira/browse/CB-11582

Let me describe the issue in more detail - I have this .\testplugin\plugin.xml:
```
<?xml version='1.0' encoding='utf-8'?>
<plugin id="testplugin" version="1" xmlns="http://apache.org/cordova/ns/plugins/1.0">
    <name>testplugin</name>
    
    <platform name="windows">
        <config-file parent="/Package/Capabilities" target="package.windows10.appxmanifest">
            <Capability Name="enterpriseAuthentication" />
            <Capability Name="sharedUserCertificates" />
        </config-file>
    </platform>
</plugin>
```

When I run `cordova create app && pushd app && cordova plugin add ..\testplugin && cordova platform add windows` the package.windows10.appxmanifest will have the capabilities set correctly. Now, everytime I run `cordova prepare`, this will duplicate all the uap-prefixed capabilities:

```
    <Capabilities>
        <Capability Name="internetClient" />
        <uap:Capability Name="enterpriseAuthentication" />
        <uap:Capability Name="sharedUserCertificates" />
        <uap:Capability Name="enterpriseAuthentication" />
        <uap:Capability Name="sharedUserCertificates" />
    </Capabilities>
```

I had a look at how the capability declarations are handled in ConfigChanges.js and AppxManifest.js. The easiest fix seems to be to just check for duplicated capabilities when writing the AppxManifest (which is what I've implemented). Another way could be to inject the uap prefixes before applying the ConfigChanges, so that the capabilities are not being duplicated in the first place.

Let me know what you think and I'll update the code accordingly.