### PR TITLE
CB-11241 Return adding BOM to www back to prepare

### DIFF
--- a/spec/unit/build.spec.js
+++ b/spec/unit/build.spec.js
@@ -88,7 +88,6 @@ describe('run method', function() {
 
         spyOn(utils, 'isCordovaProject').andReturn(true);
         spyOn(prepare, 'applyPlatformConfig');
-        spyOn(prepare, 'addBOMSignature');
         spyOn(prepare, 'updateBuildConfig');
         spyOn(package, 'getPackage').andReturn(Q({}));
 

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -49,7 +49,6 @@ var ROOT = path.resolve(__dirname, '../..');
 // See 'help' function for args list
 module.exports.run = function run (buildOptions) {
 
-    var that = this;
     ROOT = this.root || ROOT;
 
     if (!utils.isCordovaProject(this.root)){
@@ -78,9 +77,6 @@ module.exports.run = function run (buildOptions) {
     .then(function(msbuildTools) {
         // Apply build related configs
         prepare.updateBuildConfig(buildConfig);
-        // CB-5421 Add BOM to all html, js, css files
-        // to ensure app can pass Windows Store Certification
-        prepare.addBOMSignature(that.locations.www);
 
         if (buildConfig.publisherId) {
             updateManifestWithPublisher(msbuildTools, buildConfig);

--- a/template/cordova/lib/prepare.js
+++ b/template/cordova/lib/prepare.js
@@ -458,6 +458,9 @@ module.exports.prepare = function (cordovaProject, options) {
     })
     .then(function () {
         copyImages(cordovaProject, self.locations);
+        // CB-5421 Add BOM to all html, js, css files
+        // to ensure app can pass Windows Store Certification
+        addBOMSignature(self.locations.www);
     })
     .then(function () {
         events.emit('verbose', 'Prepared windows project successfully');
@@ -495,7 +498,7 @@ module.exports.clean = function (options) {
 function addBOMSignature(directory) {
     shell.ls('-R', directory)
     .forEach(function (file) {
-        if (!file.match(/\.(js|html|css|json)$/i)) {
+        if (!file.match(/\.(js|htm|html|css|json)$/i)) {
             return;
         }
 
@@ -511,8 +514,6 @@ function addBOMSignature(directory) {
         }
     });
 }
-
-module.exports.addBOMSignature = addBOMSignature;
 
 /**
  * Updates config files in project based on app's config.xml and config munge,


### PR DESCRIPTION
This PR reverts changes, made in #134

The reason of reverting is that original change causes the problems with submitting apps to Windows store when app is built using Visual Studio, because BOM signatures were being added by cordova-windows in `build.js`. In this PR processing `www` is moved back to prepare, and hence all `www` assets will be properly updated to have BOM when the project is opened in VS.

For more background see JIRA issue [CB-11241](https://issues.apache.org/jira/browse/CB-11241)