### PR TITLE
CB-11658 activated event is not fired on Windows 10 RS1

### DIFF
--- a/template/CordovaApp.Phone.jsproj
+++ b/template/CordovaApp.Phone.jsproj
@@ -97,4 +97,8 @@
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
   -->
+  <PropertyGroup>
+    <PreBuildEvent>node "$(ProjectDir)\\cordova\\prebuild-phone-81.js"</PreBuildEvent>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+  </PropertyGroup>
 </Project>

--- a/template/CordovaApp.Windows.jsproj
+++ b/template/CordovaApp.Windows.jsproj
@@ -97,4 +97,8 @@
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
   -->
+  <PropertyGroup>
+    <PreBuildEvent>node "$(ProjectDir)\\cordova\\prebuild-81.js"</PreBuildEvent>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+  </PropertyGroup>
 </Project>

--- a/template/CordovaApp.Windows10.jsproj
+++ b/template/CordovaApp.Windows10.jsproj
@@ -105,4 +105,8 @@
   <Target AfterTargets="ResolveAssemblyReferences" BeforeTargets="AfterResolveReferences" Condition="'$(Platform)' == 'AnyCPU'" Name="DetectMangedWinMDWithAnyCpu">
     <Error Condition="'%(_ResolveAssemblyReferenceResolvedFiles.WinMDFile)' == 'true' AND '%(_ResolveAssemblyReferenceResolvedFiles.WinMDFileType)' == 'Managed'" Text="The following component requires .NET Native compilation which is not available when targeting 'Windows10' and 'AnyCPU'. Consider changing the targeted processor architecture to one of the following: 'x86, x64, ARM' (if you are using command line this could be done by adding '--archs' parameter, for example: 'cordova build windows --archs=x64'). %(_ResolveAssemblyReferenceResolvedFiles.Identity)" />
     </Target>
+  <PropertyGroup>
+    <PreBuildEvent>node "$(ProjectDir)\\cordova\\prebuild-10.js"</PreBuildEvent>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+  </PropertyGroup>
 </Project>

--- a/template/cordova/prebuild-10.js
+++ b/template/cordova/prebuild-10.js
@@ -1,0 +1,2 @@
+var patch = require('./prebuild');
+patch('10');

--- a/template/cordova/prebuild-81.js
+++ b/template/cordova/prebuild-81.js
@@ -1,0 +1,2 @@
+var patch = require('./prebuild');
+patch('8.1');

--- a/template/cordova/prebuild-phone-81.js
+++ b/template/cordova/prebuild-phone-81.js
@@ -1,0 +1,2 @@
+var patch = require('./prebuild');
+patch('phone-8.1');

--- a/template/cordova/prebuild.js
+++ b/template/cordova/prebuild.js
@@ -1,0 +1,63 @@
+// https://issues.apache.org/jira/browse/CB-11658 activated event is not fired on Windows 10 RS1
+// Patching start page to include WinJS/base.js reference to HTML as a workaround
+
+module.exports = function patch(platform) {
+    console.log('Patching ' + platform + ' in prebuild event...');
+
+    var shell = require('shelljs');
+    var path = require('path');
+    var url = require('url');
+
+    var basejsSrcMap = {
+        '10': '/www/WinJS/js/base.js',
+        '8.1': '//Microsoft.WinJS.2.0/js/base.js',
+        'phone-8.1': '//Microsoft.Phone.WinJS.2.1/js/base.js'
+    };
+    var escapedBasejsSrcMap = {
+        '10': '\/www\/WinJS\/js\/base\.js',
+        '8.1': '\/\/Microsoft\.WinJS\.2\.0\/js\/base\.js',
+        'phone-8.1': '\/\/Microsoft\.Phone\.WinJS\.2\.1\/js\/base\.js'
+    };
+    var basejsSrc = basejsSrcMap[platform];
+
+    var appxmanifestMap = {
+        '10': 'package.windows10.appxmanifest',
+        '8.1': 'package.windows.appxmanifest',
+        'phone-8.1': 'package.phone.appxmanifest'
+    };
+
+    // 1. Find start page path in appxmanifest
+    var AppxManifest = require('./lib/AppxManifest');
+    var appxmanifest = AppxManifest.get(path.join(__dirname, '..', appxmanifestMap[platform]));
+    var startPage = url.parse(appxmanifest.getApplication().getStartPage());
+
+    if (startPage.protocol && startPage.protocol.indexOf('http') === 0) {
+        console.warn('Warning: Can\'t modify external content.src. You should update your server-side pages to reference WinJS directly in HTML.');
+        return;
+    }
+
+    // Discard scheme and identity name (host)
+    startPage = startPage.pathname;
+
+    // 2. Check if start page HTML contains base.js reference
+    var startPageFilePath = shell.ls(path.join(__dirname, '..', startPage))[0];
+    var reBaseJs = new RegExp(escapedBasejsSrcMap[platform], 'i');
+
+    if (shell.grep(reBaseJs, startPageFilePath).length === 0) {
+        // 3. If it doesn't - patch page to include base.js ref before cordova.js
+        var appendBaseJsRe = /( *)(<script\s+(?:type="text\/javascript"\s+)?src="cordova\.js">\s*<\/script>)/;
+        var subst = '$1<script type="text/javascript" src="' + basejsSrc + '"></script>\n$1$2';
+
+        shell.sed('-i', appendBaseJsRe, subst, startPageFilePath);
+        console.log('Injected base.js reference to the ' + startPage);
+
+        // 4. Remove all 'wrong' base.js references, which might left from another project type build:
+        for (var plat in basejsSrcMap) {
+            if (plat !== platform) {
+                var wrongBaseJsRe = new RegExp('( *)(<script\\s+(?:type="text\\/javascript"\\s+)?src="' + escapedBasejsSrcMap[plat] + '">\\s*<\\/script>)(\\s*)');
+                console.log('Removing ' + wrongBaseJsRe + ' from ' + startPage);
+                shell.sed('-i', wrongBaseJsRe, '$1', startPageFilePath);
+            }
+        }
+    }
+};


### PR DESCRIPTION
Patch start page to include base.js reference to HTML as a workaround

[Jira issue](https://issues.apache.org/jira/browse/CB-11658)