### PR TITLE
CB-10738 Use hardcoded Id attribute in Win10 manifest

### DIFF
--- a/template/package.windows10.appxmanifest
+++ b/template/package.windows10.appxmanifest
@@ -46,7 +46,7 @@
 
   <Applications>
     <Application
-      Id="$safeprojectname$"
+      Id="App"
       StartPage="www/index.html">
 
       <uap:VisualElements
@@ -57,9 +57,9 @@
         Square44x44Logo="images\Square44x44Logo.png">
 
         <uap:SplashScreen Image="images\splashscreen.png" />
-        <uap:DefaultTile ShortName="$projectname$" 
+        <uap:DefaultTile ShortName="$projectname$"
                          Square310x310Logo="images\Square310x310Logo.png"
-                         Square71x71Logo="images\Square71x71Logo.png" 
+                         Square71x71Logo="images\Square71x71Logo.png"
                          Wide310x150Logo="images\Wide310x150Logo.png" />
 
       </uap:VisualElements>


### PR DESCRIPTION
Similarly to #66 this replaces faulty `Id` attribute value to hardcoded 'App' string, preventing build failure of clean cordova-windows project.

Related issue - [CB-10738](https://issues.apache.org/jira/browse/CB-10738)