### PR TITLE
CB-11836 Allow setting of 'ForegroundText' property via config.xml

### DIFF
--- a/spec/unit/AppxManifest.spec.js
+++ b/spec/unit/AppxManifest.spec.js
@@ -187,6 +187,27 @@ describe('AppxManifest', function () {
         it('refineColor should leave CSS color name as is', function () {
             expect(refineColor(CSS_COLOR_NAME)).toEqual(CSS_COLOR_NAME);
         });
+        
+        it('setForegroundText should change the ForegroundText property on non-Windows 10 platforms', function () {
+            var visualElementsWindows = AppxManifest.get(WINDOWS_MANIFEST).getVisualElements();
+            var visualElementsWindows10 = AppxManifest.get(WINDOWS_10_MANIFEST).getVisualElements();
+            
+            var foregroundTextLight = 'light';
+            var foregroundTextDark = 'dark';
+            
+            // Set to 'light'
+            visualElementsWindows.setForegroundText(foregroundTextLight);
+            expect(visualElementsWindows.getForegroundText()).toEqual(foregroundTextLight);
+            
+            // Set to 'dark'
+            visualElementsWindows.setForegroundText(foregroundTextDark);
+            expect(visualElementsWindows.getForegroundText()).toEqual(foregroundTextDark);
+            
+            // Returns nothing on Windows 10
+            visualElementsWindows10.setForegroundText(foregroundTextLight);
+            expect(visualElementsWindows10.getForegroundText()).toEqual(undefined);
+        });
+        
     });
 });
 

--- a/spec/unit/AppxManifest.spec.js
+++ b/spec/unit/AppxManifest.spec.js
@@ -194,6 +194,7 @@ describe('AppxManifest', function () {
             
             var foregroundTextLight = 'light';
             var foregroundTextDark = 'dark';
+            var foregroundTextDefault = foregroundTextLight;
             
             // Set to 'light'
             visualElementsWindows.setForegroundText(foregroundTextLight);
@@ -202,6 +203,10 @@ describe('AppxManifest', function () {
             // Set to 'dark'
             visualElementsWindows.setForegroundText(foregroundTextDark);
             expect(visualElementsWindows.getForegroundText()).toEqual(foregroundTextDark);
+            
+            // Simulate removal of preference, should change back to default vlaue 'light'
+            visualElementsWindows.setForegroundText(undefined);
+            expect(visualElementsWindows.getForegroundText()).toEqual(foregroundTextDefault);
             
             // Returns nothing on Windows 10
             visualElementsWindows10.setForegroundText(foregroundTextLight);

--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -604,6 +604,10 @@ Win10AppxManifest.prototype.getVisualElements = function () {
     // See https://msdn.microsoft.com/ru-ru/library/windows/apps/dn423310.aspx
     result.getToastCapable = function () {};
     result.setToastCapable = function () { return this; };
+    
+    // ForegroundText was removed in Windows 10 as well
+    result.getForegroundText = function () {};
+    result.setForegroundText = function () { return this; };
 
     return result;
 };

--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -391,8 +391,8 @@ AppxManifest.prototype.getVisualElements = function () {
         setForegroundText: function (color) {
             if (color) {
                 // Foreground color can either be dark or light, light is the default
-                if (color !== "dark") {
-                    color = "light";
+                if (color !== 'dark') {
+                    color = 'light';
                 }
 
                 visualElements.attrib.ForegroundText = color;

--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -390,11 +390,6 @@ AppxManifest.prototype.getVisualElements = function () {
         },
         setForegroundText: function (color) {
             if (color) {
-                // Foreground color can either be dark or light, light is the default
-                if (color !== 'dark') {
-                    color = 'light';
-                }
-
                 visualElements.attrib.ForegroundText = color;
             }
             

--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -389,9 +389,8 @@ AppxManifest.prototype.getVisualElements = function () {
             return visualElements.attrib.ForegroundText;
         },
         setForegroundText: function (color) {
-            if (color) {
-                visualElements.attrib.ForegroundText = color;
-            }
+            // If color is not set, fall back to 'light' by default
+            visualElements.attrib.ForegroundText = color || 'light'; 
             
             return this;
         },

--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -385,6 +385,21 @@ AppxManifest.prototype.getVisualElements = function () {
                 return this.setBackgroundColor(color);
             } catch (e) { return this; }
         },
+        getForegroundText: function () {
+            return visualElements.attrib.ForegroundText;
+        },
+        setForegroundText: function (color) {
+            if (color) {
+                // Foreground color can either be dark or light, light is the default
+                if (color !== "dark") {
+                    color = "light";
+                }
+
+                visualElements.attrib.ForegroundText = color;
+            }
+            
+            return this;
+        },
         getSplashBackgroundColor: function () {
             var splashNode = visualElements.find('./' + self.prefix + 'SplashScreen');
             return splashNode && splashNode.attrib.BackgroundColor;

--- a/template/cordova/lib/prepare.js
+++ b/template/cordova/lib/prepare.js
@@ -131,6 +131,7 @@ function updateManifestFile (config, manifestPath) {
     // Apply background color, splashscreen background color, etc.
     manifest.getVisualElements()
         .trySetBackgroundColor(config.getPreference('BackgroundColor'))
+        .setForegroundText(config.getPreference('ForegroundText'))
         .setSplashBackgroundColor(config.getPreference('SplashScreenBackgroundColor'))
         .setToastCapable(config.getPreference('WindowsToastCapable'))
         .setOrientation(config.getPreference('Orientation'));


### PR DESCRIPTION
We had a problem when trying to release an app in the Windows Store with BackgroundColor set to white because of the contrast between background and foreground color. With this PR, you can set the foreground color to 'dark' in these cases to pass store certification.