### PR TITLE
Fix setSplashBgColor exception when no splashscreen is found

### DIFF
--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -391,10 +391,12 @@ AppxManifest.prototype.getVisualElements = function () {
         },
         setSplashBackgroundColor: function (color) {
             var splashNode = visualElements.find('./' + self.prefix + 'SplashScreen');
-            if (color && splashNode) {
-                splashNode.attrib.BackgroundColor = refineColor(color);
-            } else if (!color) {
-                delete splashNode.attrib.BackgroundColor;
+            if (splashNode) {
+                if (color) {
+                    splashNode.attrib.BackgroundColor = refineColor(color);
+                } else {
+                    delete splashNode.attrib.BackgroundColor;
+                }
             }
             return this;
         },


### PR DESCRIPTION
WindowsPhone allows to unset splashscreen (img) to avoid it to be shown.
This patch fixes whenever the "splashscreen" node is not present.