### PR TITLE
CB-11999 platformAPIs contain js code that is deceptively uncallable

### DIFF
--- a/template/cordova/Api.js
+++ b/template/cordova/Api.js
@@ -86,14 +86,24 @@ function Api(platform, platformRootDir, eventEmitter) {
  * @return {Promise<PlatformApi>} Promise either fulfilled with PlatformApi
  *   instance or rejected with CordovaError.
  */
-Api.createPlatform = function (destinationDir, projectConfig, options, eventEmitter) {
-    setupEvents(eventEmitter);
-    return require('../../bin/lib/create')
-    .create(destinationDir, projectConfig, options)
-    .then(function () {
-        var PlatformApi = require(path.resolve(destinationDir, 'cordova/Api'));
-        return new PlatformApi(PLATFORM, destinationDir, eventEmitter);
-    });
+Api.createPlatform = function (destinationDir, projectConfig, options, events) {
+    setupEvents(events);
+    var result;
+
+    try {
+        result = require('../../bin/lib/create')
+        .create(destinationDir, projectConfig, options)
+        .then(function () {
+            var PlatformApi = require(path.resolve(destinationDir, 'cordova/Api'));
+            return new PlatformApi(PLATFORM, destinationDir, events);
+        });
+    }
+    catch(e) {
+        events.emit('error','createPlatform is not callable from the windows project API.');
+        throw(e);
+    }
+
+    return result;
 };
 
 /**
@@ -106,19 +116,25 @@ Api.createPlatform = function (destinationDir, projectConfig, options, eventEmit
  *   should override the default one from platform.
  * @param  {Boolean}  [options.link=false]  Flag that indicates that platform's sources
  *   will be linked to installed platform instead of copying.
- * @param {EventEmitter} [eventEmitter] The emitter that will be used for logging
+ * @param {EventEmitter} [events] The emitter that will be used for logging
  *
  * @return {Promise<PlatformApi>} Promise either fulfilled with PlatformApi
  *   instance or rejected with CordovaError.
  */
-Api.updatePlatform = function (destinationDir, options, eventEmitter) {
-    setupEvents(eventEmitter);
-    return require('../../bin/lib/update')
-    .update(destinationDir, options)
-    .then(function () {
-        var PlatformApi = require(path.resolve(destinationDir, 'cordova/Api'));
-        return new PlatformApi(PLATFORM, destinationDir, eventEmitter);
-    });
+Api.updatePlatform = function (destinationDir, options, events) {
+    setupEvents(events);
+    try {
+        return require('../../bin/lib/update')
+        .update(destinationDir, options)
+        .then(function () {
+            var PlatformApi = require(path.resolve(destinationDir, 'cordova/Api'));
+            return new PlatformApi(PLATFORM, destinationDir, events);
+        });
+    }
+    catch(e) {
+        events.emit('error','updatePlatform is not callable from the windows project API.');
+        throw(e);
+    }
 };
 
 /**


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
windows

### What does this PR do?
catches possible error

### What testing has been done on this change?
jshint

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
