### PR TITLE
CB-11993 - windows platform doesn't test all node versions on appveyor and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: node_js
 sudo: false
+git:
+  depth: 10
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "6"
 install:
     - npm install
     - npm install -g codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,15 @@
 # appveyor file
 # http://www.appveyor.com/docs/appveyor-yml
 
+environment:
+  matrix:
+  - nodejs_version: "0.10"
+  - nodejs_version: "0.12"
+  - nodejs_version: "4"
+  - nodejs_version: "6"
+
 install:
+  - ps: Install-Product node $env:nodejs_version
   - npm install
 
 build: off

--- a/spec/unit/deployment.spec.js
+++ b/spec/unit/deployment.spec.js
@@ -29,6 +29,20 @@ var TEST_APP_PACKAGE_NAME = '"c:\\testapppackage.appx"',
 
 describe('The correct version of the app deployment tool is obtained.', function() {
 
+    var mockedProgramFiles = process.env['ProgramFiles(x86)'];
+
+    beforeEach(function() {
+        process.env['ProgramFiles(x86)'] = path.join('c:/Program Files (x86)');
+    });
+
+    afterEach(function() {
+        if (mockedProgramFiles) {
+            process.env['ProgramFiles(x86)'] = mockedProgramFiles;
+        } else {
+            delete process.env['ProgramFiles(x86)'];
+        }
+    });
+
     it('Provides an AppDeployCmdTool when 8.1 is requested.', function() {
 
         var tool = deployment.getDeploymentTool('8.1');


### PR DESCRIPTION
### Platforms affected

Self.

### What does this PR do?

Makes appveyor and travis CI test for all node versions.

### What testing has been done on this change?

We'll find out if this PR passes on appveyor or travis, since we are modifying the CI config files themselves.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

