### PR TITLE
CB-11933: Remove capabilities from manifest

### DIFF
--- a/spec/unit/fixtures/org.test.plugins.capabilityplugin/plugin.xml
+++ b/spec/unit/fixtures/org.test.plugins.capabilityplugin/plugin.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='utf-8'?>
+<plugin id="org.test.plugins.capabilityplugin" version="0.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+    <name>org.test.plugins.capabilityplugin</name>
+    <js-module name="org.test.plugins.capabilityplugin" src="www/org.test.plugins.capabilityplugin.js">
+        <clobbers target="cordova.plugins.org.test.plugins.capabilityplugin" />
+    </js-module>
+    <config-file target="package.appxmanifest" parent="/Package/Capabilities" device-target="windows">
+        <Capability Name="enterpriseAuthentication" />
+        <Capability Name="privateNetworkClientServer" />
+        <Capability Name="sharedUserCertificates" />
+    </config-file>
+</plugin>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### What does this PR do?
Windows has special logic for appxmanifest's capabilities removal, therefore we should override this behaviour

### What testing has been done on this change?
Auto test

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

