### PR TITLE
CB-11933: Add uap prefixes for capabilities from package.windows10.appxmanifest when installing plugin

### DIFF
--- a/spec/unit/ConfigChanges.spec.js
+++ b/spec/unit/ConfigChanges.spec.js
@@ -63,7 +63,6 @@ describe('PlatformMunger', function () {
         it('should additionally call parent\'s method with another munge if removing changes from windows 10 appxmanifest', function () {
             munger.apply_file_munge(WINDOWS10_MANIFEST, munge, /*remove=*/true);
             expect(BaseMunger.prototype.apply_file_munge).toHaveBeenCalledWith(WINDOWS10_MANIFEST, munge, true);
-            expect(BaseMunger.prototype.apply_file_munge).toHaveBeenCalledWith(WINDOWS10_MANIFEST, jasmine.any(Object), true);
         });
 
         it('should remove uap: capabilities added by windows prepare step', function () {

--- a/spec/unit/fixtures/testProj/platforms/windows/package.windows10.appxmanifest
+++ b/spec/unit/fixtures/testProj/platforms/windows/package.windows10.appxmanifest
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+-->
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  IgnorableNamespaces="uap mp">
+
+  <Identity
+    Name="$guid1$"
+    Version="1.0.0.0"
+    Publisher="CN=$username$" />
+
+  <mp:PhoneIdentity PhoneProductId="$guid1$" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
+
+  <Properties>
+    <DisplayName>$projectname$</DisplayName>
+    <PublisherDisplayName>$username$</PublisherDisplayName>
+    <Logo>images\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="0.0.0.0" MaxVersionTested="10.0.0.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+
+  <Applications>
+    <Application
+      Id="App"
+      StartPage="www/index.html">
+
+      <uap:VisualElements
+        DisplayName="$projectname$"
+        Description="CordovaApp"
+        BackgroundColor="#464646"
+        Square150x150Logo="images\Square150x150Logo.png"
+        Square44x44Logo="images\Square44x44Logo.png">
+
+        <uap:SplashScreen Image="images\splashscreen.png" />
+        <uap:DefaultTile ShortName="$projectname$"
+                         Square310x310Logo="images\Square310x310Logo.png"
+                         Square71x71Logo="images\Square71x71Logo.png"
+                         Wide310x150Logo="images\Wide310x150Logo.png" />
+
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <Capability Name="internetClient" />
+  </Capabilities>
+
+</Package>

--- a/template/cordova/Api.js
+++ b/template/cordova/Api.js
@@ -208,7 +208,10 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
         installOptions.variables.PACKAGE_NAME = jsProject.getPackageName();
     }
 
-    return PluginManager.get(this.platform, this.locations, jsProject)
+    var platformJson = PlatformJson.load(this.root, this.platform);
+    var pluginManager = PluginManager.get(this.platform, this.locations, jsProject);
+    pluginManager.munger = new PlatformMunger(this.platform, this.locations.root, platformJson, new PluginInfoProvider());
+    return pluginManager
         .addPlugin(plugin, installOptions)
         .then(function () {
             // CB-11657 Add BOM to www files here because files added by plugin

--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -72,6 +72,13 @@ function AppxManifest(path, prefix) {
     this.hasPhoneIdentity = this.prefix === 'uap:' || this.prefix === 'm3:';
 }
 
+//  Static read-only property to get capabilities which need to be prefixed with uap
+Object.defineProperty(AppxManifest, 'CapsNeedUapPrefix', {
+    writable: false,
+    configurable: false,
+    value: CAPS_NEEDING_UAPNS
+});
+
 /**
  * @static
  * @constructs AppxManifest|Win10AppxManifest

--- a/template/cordova/lib/ConfigChanges.js
+++ b/template/cordova/lib/ConfigChanges.js
@@ -44,16 +44,21 @@ PlatformMunger.prototype.apply_file_munge = function (file, munge, remove) {
     var mungeCopy = cloneObject(munge);
     var capabilities = mungeCopy.parents[CAPS_SELECTOR];
 
-    // Add 'uap' prefixes for windows 10 manifest
-    if (file === WINDOWS10_MANIFEST)
-        capabilities = generateUapCapabilities(capabilities);
+    if (capabilities) {
+        // Add 'uap' prefixes for windows 10 manifest
+        if (file === WINDOWS10_MANIFEST) {
+            capabilities = generateUapCapabilities(capabilities);
+        }
 
-    // Remove duplicates and sort capabilities when installing plugin
-    if (!remove)
-        capabilities = getUniqueCapabilities(capabilities).sort(compareCapabilities);
+        // Remove duplicates and sort capabilities when installing plugin
+        if (!remove) {
+            capabilities = getUniqueCapabilities(capabilities).sort(compareCapabilities);
+        }
 
-    // Put back capabilities into munge's copy
-    mungeCopy.parents[CAPS_SELECTOR] = capabilities;
+        // Put back capabilities into munge's copy
+        mungeCopy.parents[CAPS_SELECTOR] = capabilities;
+    }
+
     PlatformMunger.super_.prototype.apply_file_munge.call(this, file, mungeCopy, remove);
 };
 
@@ -87,7 +92,6 @@ function getCapabilityName(capability) {
  * @return {Object} an unique array of capabilities
  */
 function getUniqueCapabilities(capabilities) {
-    capabilities = capabilities || [];
     return capabilities.reduce(function(uniqueCaps, currCap) {
 
         var isRepeated = uniqueCaps.some(function(cap) {
@@ -147,7 +151,6 @@ function generateUapCapabilities(capabilities) {
         };
     }
 
-    capabilities = capabilities || [];
     return capabilities
      // For every xml change check if it adds a <Capability> element ...
     .filter(hasCapabilityChange)

--- a/template/cordova/lib/ConfigChanges.js
+++ b/template/cordova/lib/ConfigChanges.js
@@ -15,7 +15,12 @@
 */
 
 var util = require('util');
+var path = require('path');
 var CommonMunger = require('cordova-common').ConfigChanges.PlatformMunger;
+var CapsNeedUapPrefix = require(path.join(__dirname, 'AppxManifest')).CapsNeedUapPrefix;
+
+var CAPS_SELECTOR = '/Package/Capabilities';
+var WINDOWS10_MANIFEST = 'package.windows10.appxmanifest';
 
 function PlatformMunger(platform, project_dir, platformJson, pluginInfoProvider) {
     CommonMunger.apply(this, arguments);
@@ -34,19 +39,86 @@ util.inherits(PlatformMunger, CommonMunger);
  *   need to be removed or added to the file
  */
 PlatformMunger.prototype.apply_file_munge = function (file, munge, remove) {
-    // Call parent class' method
-    PlatformMunger.super_.prototype.apply_file_munge.call(this, file, munge, remove);
 
-    // CB-11066 If this is a windows10 manifest and we're removing the changes
-    // then we also need to check if there are <Capability> elements were previously
-    // added and schedule removal of corresponding <uap:Capability> elements
-    if (remove && file === 'package.windows10.appxmanifest') {
-        var uapCapabilitiesMunge = generateUapCapabilities(munge);
-        // We do not check whether generated munge is empty or not before calling
-        // 'apply_file_munge' since applying empty one is just a no-op
-        PlatformMunger.super_.prototype.apply_file_munge.call(this, file, uapCapabilitiesMunge, remove);
-    }
+    // Create a copy to avoid modification of original munge
+    var mungeCopy = cloneObject(munge);
+    var capabilities = mungeCopy.parents[CAPS_SELECTOR];
+
+    // Add 'uap' prefixes for windows 10 manifest
+    if (file === WINDOWS10_MANIFEST)
+        capabilities = generateUapCapabilities(capabilities);
+
+    // Remove duplicates and sort capabilities when installing plugin
+    if (!remove)
+        capabilities = getUniqueCapabilities(capabilities).sort(compareCapabilities);
+
+    // Put back capabilities into munge's copy
+    mungeCopy.parents[CAPS_SELECTOR] = capabilities;
+    PlatformMunger.super_.prototype.apply_file_munge.call(this, file, mungeCopy, remove);
 };
+
+// Recursive function to clone an object
+function cloneObject(obj) {
+    if (obj === null || typeof obj !== 'object') {
+        return obj;
+    }
+
+    var copy = obj.constructor();
+    Object.keys(obj).forEach(function(key) {
+        copy[key] = cloneObject(obj[key]);
+    });
+
+    return copy;
+}
+
+/**
+ * Retrieve capabality name from xml field
+ * @param {Object} capability with xml field like <Capability Name="CapabilityName">
+ * @return {String} name of capability
+ */
+function getCapabilityName(capability) {
+    var reg = /Name="(\w+)"/i;
+    return capability.xml.match(reg)[1];
+}
+
+/**
+ * Remove capabilities with same names
+ * @param {Object} an array of capabilities
+ * @return {Object} an unique array of capabilities
+ */
+function getUniqueCapabilities(capabilities) {
+    capabilities = capabilities || [];
+    return capabilities.reduce(function(uniqueCaps, currCap) {
+
+        var isRepeated = uniqueCaps.some(function(cap) {
+            return getCapabilityName(cap) === getCapabilityName(currCap);
+        });
+
+        return isRepeated ? uniqueCaps : uniqueCaps.concat([currCap]);
+    }, []);
+}
+
+/**
+ * Comparator function to pass to Array.sort
+ * @param {Object} firstCap first capability
+ * @param {Object} secondCap second capability
+ * @return {Number} either -1, 0 or 1
+ */
+function compareCapabilities(firstCap, secondCap) {
+    var firstCapName = getCapabilityName(firstCap);
+    var secondCapName = getCapabilityName(secondCap);
+
+    if (firstCapName < secondCapName) {
+        return -1;
+    }
+
+    if (firstCapName > secondCapName) {
+        return 1;
+    }
+
+    return 0;
+}
+
 
 /**
  * Generates a new munge that contains <uap:Capability> elements created based on
@@ -54,16 +126,20 @@ PlatformMunger.prototype.apply_file_munge = function (file, munge, remove) {
  * found in base munge, the empty munge is returned (selectors might be present under
  * the 'parents' key, but they will contain no changes).
  *
- * @param {Object} munge A munge that we need to check for <Capability> elements
- * @return {Object} A munge with 'uap'-prefixed capabilities or empty one
+ * @param {Object} capabilities A list of capabilities
+ * @return {Object} A list with 'uap'-prefixed capabilities
  */
-function generateUapCapabilities(munge) {
+function generateUapCapabilities(capabilities) {
 
     function hasCapabilityChange(change) {
         return /^\s*<Capability\s/.test(change.xml);
     }
 
     function createPrefixedCapabilityChange(change) {
+        if (CapsNeedUapPrefix.indexOf(getCapabilityName(change)) < 0) {
+            return change;
+        }
+
         return {
             xml: change.xml.replace(/Capability/, 'uap:Capability'),
             count: change.count,
@@ -71,17 +147,13 @@ function generateUapCapabilities(munge) {
         };
     }
 
-    // Iterate through all selectors in munge
-    return Object.keys(munge.parents)
-    .reduce(function (result, selector) {
-        result.parents[selector] = munge.parents[selector]
-        // For every xml change check if it adds a <Capability> element ...
-        .filter(hasCapabilityChange)
-        // ... and create a duplicate with 'uap:' prefix
-        .map(createPrefixedCapabilityChange);
+    capabilities = capabilities || [];
+    return capabilities
+     // For every xml change check if it adds a <Capability> element ...
+    .filter(hasCapabilityChange)
+    // ... and create a duplicate with 'uap:' prefix
+    .map(createPrefixedCapabilityChange);
 
-        return result;
-    }, { parents: {} });
 }
 
 exports.PlatformMunger = PlatformMunger;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### What does this PR do?
Windows has a special logic for adding appxmanifest's capabilities. This PR adds uap prefixes to capabilities from package.windows10.appxmanifest when installing plugin.

### What testing has been done on this change?
Auto test

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.