### PR TITLE
CB-12042 Copy base.js to www directory in 'create'

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -92,6 +92,10 @@ module.exports.create = function (destinationDir, config, options) {
     recursiveCreateDirectory(destinationDirectory);
     shell.cp('-f', srcBaseJsPath, destBaseJsPath);
 
+    // CB-12042 Also copy base.js to www directory
+    shell.mkdir('-p', path.join(projectPath, 'www/WinJS/js'));
+    shell.cp('-f', srcBaseJsPath, path.join(projectPath, 'www/WinJS/js/base.js'));
+
     // replace specific values in manifests' templates
     events.emit('verbose', 'Updating manifest files with project configuration.');
     [ 'package.windows.appxmanifest', 'package.phone.appxmanifest',


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### What does this PR do?
Fixes missing `base.js` in `www` folder when project is created without Cordova CLI

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [-] Added automated test coverage as appropriate for this change.

