### PR TITLE
CB-12071 Fix for CB-11825 breaks usage of InProcessServer in Cordova Windows

### DIFF
--- a/spec/unit/pluginHandler/windows.spec.js
+++ b/spec/unit/pluginHandler/windows.spec.js
@@ -216,16 +216,16 @@ describe('windows project handler', function () {
             // project files, which is not needed.
             it('should write to correct project files when conditions are specified', function () {
 
-                var xpath = 'None[@Include="' + computeResourcePath(resourceFiles[0]) + '"][@Condition="\'$(Platform)\'==\'x86\'"]';
+                var xpath = 'Content[@Include="' + computeResourcePath(resourceFiles[0]) + '"][@Condition="\'$(Platform)\'==\'x86\'"]';
                 validateInstalledProjects('resource-file', resourceFiles[0], xpath, ['all']);
 
-                xpath = 'None[@Include="' + computeResourcePath(resourceFiles[1]) + '"]';
+                xpath = 'Content[@Include="' + computeResourcePath(resourceFiles[1]) + '"]';
                 validateInstalledProjects('resource-file', resourceFiles[1], xpath, ['windows', 'phone', 'windows10']);
 
-                xpath = 'None[@Include="' + computeResourcePath(resourceFiles[2]) + '"]';
+                xpath = 'Content[@Include="' + computeResourcePath(resourceFiles[2]) + '"]';
                 validateInstalledProjects('resource-file', resourceFiles[2], xpath, ['phone']);
 
-                xpath = 'None[@Include="' + computeResourcePath(resourceFiles[3]) + '"][@Condition="\'$(Platform)\'==\'x64\'"]';
+                xpath = 'Content[@Include="' + computeResourcePath(resourceFiles[3]) + '"][@Condition="\'$(Platform)\'==\'x64\'"]';
                 validateInstalledProjects('resource-file', resourceFiles[3], xpath, ['windows8']);
             });
 
@@ -454,7 +454,7 @@ describe('windows project handler', function () {
                 resourcefiles.forEach(function(resourceFile) {
                     install(resourceFile, dummyPluginInfo, dummyProject);
                 });
-                var path = 'ItemGroup/None';
+                var path = 'ItemGroup/Content';
                 var incText = computeResourcePath(resourcefiles[0]);
                 var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x86'};
                 validateUninstalledProjects('resource-file', resourcefiles[0], path, incText, targetConditions, ['all']);

--- a/template/cordova/lib/JsprojManager.js
+++ b/template/cordova/lib/JsprojManager.js
@@ -121,7 +121,7 @@ jsprojManager.prototype = {
         copyToOutputDirectory.text = 'Always';
         children.push(copyToOutputDirectory);
 
-        var item = createItemGroupElement('ItemGroup/None', sourcePath, targetConditions, children);
+        var item = createItemGroupElement('ItemGroup/Content', sourcePath, targetConditions, children);
         this._getMatchingProjects(targetConditions).forEach(function (project) {
             project.appendToRoot(item);
         });
@@ -130,7 +130,7 @@ jsprojManager.prototype = {
     removeResourceFileFromProject: function (relPath, targetConditions) {
         events.emit('verbose', 'jsprojManager.removeResourceFile(relPath: ' + relPath + ', targetConditions: ' + JSON.stringify(targetConditions) + ')');
         this._getMatchingProjects(targetConditions).forEach(function (project) {
-            project.removeItemGroupElement('ItemGroup/None', relPath, targetConditions);
+            project.removeItemGroupElement('ItemGroup/Content', relPath, targetConditions);
         });
     },
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
The real issue in CB-11825 was in a wrong plugin configuration - resource-file.target (Content.Link) should use backslashes (reverted from commit 1417b932c836c0fe21cca902e5098fa12e98fe82)

### What testing has been done on this change?
Run platform autotests, created and run helloworld project

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
