### PR TITLE
CB-12142: Move windows-specific logic from cordova-common

### DIFF
--- a/spec/unit/ConfigChanges.spec.js
+++ b/spec/unit/ConfigChanges.spec.js
@@ -81,6 +81,7 @@ describe('PlatformMunger', function () {
             ]}};
 
             var capabilitiesMunge = { parents: { '/Package/Capabilities': [
+                { before: undefined, count: 1, xml: '<uap:Capability Name=\"privateNetworkClientServer\">'},
                 { before: undefined, count: 1, xml: '<uap:Capability Name=\"enterpriseAuthentication\">'}
             ]}};
             munger.apply_file_munge(WINDOWS10_MANIFEST, baseMunge, /*remove=*/true);

--- a/spec/unit/fixtures/org.test.configtest/plugin.xml
+++ b/spec/unit/fixtures/org.test.configtest/plugin.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright 2013 Anis Kadri
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.test.configtest"
+    version="3.0.0">
+
+    <name>Does Code Fil Write Even Work? Hopefully the Tests Will Tell Us</name>
+
+    <!-- android -->
+    <platform name="android">
+        <config-file target="res/xml/config.xml" parent="/widget">
+            <poop/>
+        </config-file>
+        <config-file target="res/xml/config.xml" parent="/widget">
+            <poop/>
+        </config-file>
+    </platform>
+
+    <platform name="windows">
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities">
+            <Capability Note="should-exist-for-all-appxmanifest-target-files" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions="=8.1.0">
+            <Capability Note="should-exist-for-win81-win-and-phone" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions="=8.1.0" device-target="windows">
+            <Capability Note="should-exist-for-win81-win-only" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions="=8.1.0" device-target="phone">
+            <Capability Note="should-exist-for-win81-phone-only" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions="=8.1.0" device-target="all">
+            <Capability Note="should-exist-for-win81-win-and-phone" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions="<=10.0.0" device-target="all">
+            <Capability Note="should-exist-for-win10-and-win81-win-and-phone" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions=">=10.0.0">
+            <Capability Note="should-exist-in-win10-only" />
+        </config-file>
+    </platform>
+</plugin>

--- a/template/cordova/Api.js
+++ b/template/cordova/Api.js
@@ -24,6 +24,7 @@ var PluginManager = require('cordova-common').PluginManager;
 var CordovaLogger = require('cordova-common').CordovaLogger;
 var PlatformMunger = require('./lib/ConfigChanges.js').PlatformMunger;
 var PlatformJson = require('cordova-common').PlatformJson;
+var PluginInfo = require('./lib/PluginInfo').PluginInfo;
 var PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 
 var PLATFORM = 'windows';
@@ -200,6 +201,9 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
 
     var self = this;
 
+    // We need to use custom PluginInfo to trigger windows-specific processing
+    // of changes in .appxmanifest files. See PluginInfo.js for details
+    var pluginInfo = new PluginInfo(plugin.dir);
     var jsProject = JsprojManager.getProject(this.root);
     installOptions = installOptions || {};
     installOptions.variables = installOptions.variables || {};
@@ -212,7 +216,7 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
     var pluginManager = PluginManager.get(this.platform, this.locations, jsProject);
     pluginManager.munger = new PlatformMunger(this.platform, this.locations.root, platformJson, new PluginInfoProvider());
     return pluginManager
-        .addPlugin(plugin, installOptions)
+        .addPlugin(pluginInfo, installOptions)
         .then(function () {
             // CB-11657 Add BOM to www files here because files added by plugin
             // probably don't have it. Prepare would add BOM but it might not be called
@@ -238,6 +242,10 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
  */
 Api.prototype.removePlugin = function (plugin, uninstallOptions) {
     var self = this;
+
+    // We need to use custom PluginInfo to trigger windows-specific processing
+    // of changes in .appxmanifest files. See PluginInfo.js for details
+    var pluginInfo = new PluginInfo(plugin.dir);
     var jsProject = JsprojManager.getProject(this.root);
     var platformJson = PlatformJson.load(this.root, this.platform);
     var pluginManager = PluginManager.get(this.platform, this.locations, jsProject);
@@ -245,7 +253,7 @@ Api.prototype.removePlugin = function (plugin, uninstallOptions) {
     //  for appxmanifest's capabilities removal (see also https://issues.apache.org/jira/browse/CB-11066)
     pluginManager.munger = new PlatformMunger(this.platform, this.locations.root, platformJson, new PluginInfoProvider());
     return pluginManager
-        .removePlugin(plugin, uninstallOptions)
+        .removePlugin(pluginInfo, uninstallOptions)
         .then(function () {
             // CB-11657 Add BOM to cordova_plugins, since it is was
             // regenerated after plugin uninstallation and does not have BOM

--- a/template/cordova/lib/ConfigChanges.js
+++ b/template/cordova/lib/ConfigChanges.js
@@ -136,7 +136,7 @@ function compareCapabilities(firstCap, secondCap) {
 function generateUapCapabilities(capabilities) {
 
     function hasCapabilityChange(change) {
-        return /^\s*<(Device)?Capability\s/.test(change.xml);
+        return /^\s*<(\w+:)?(Device)?Capability\s/.test(change.xml);
     }
 
     function createPrefixedCapabilityChange(change) {
@@ -144,8 +144,10 @@ function generateUapCapabilities(capabilities) {
             return change;
         }
 
+        //  If capability is already prefixed, avoid adding another prefix
+        var replaceXML = change.xml.indexOf('uap:') > 0 ? change.xml : change.xml.replace(/Capability/, 'uap:Capability');
         return {
-            xml: change.xml.replace(/Capability/, 'uap:Capability'),
+            xml: replaceXML,
             count: change.count,
             before: change.before
         };

--- a/template/cordova/lib/ConfigChanges.js
+++ b/template/cordova/lib/ConfigChanges.js
@@ -82,7 +82,7 @@ function cloneObject(obj) {
  * @return {String} name of capability
  */
 function getCapabilityName(capability) {
-    var reg = /Name="(\w+)"/i;
+    var reg = /Name\s*=\s*"(.*?)"/;
     return capability.xml.match(reg)[1];
 }
 

--- a/template/cordova/lib/PluginInfo.js
+++ b/template/cordova/lib/PluginInfo.js
@@ -1,0 +1,120 @@
+var semver = require('semver');
+var CommonPluginInfo = require('cordova-common').PluginInfo;
+
+var MANIFESTS = {
+    'windows': {
+        '8.1.0': 'package.windows.appxmanifest',
+        '10.0.0': 'package.windows10.appxmanifest'
+    },
+    'phone': {
+        '8.1.0': 'package.phone.appxmanifest',
+        '10.0.0': 'package.windows10.appxmanifest'
+    },
+    'all': {
+        '8.1.0': ['package.windows.appxmanifest', 'package.phone.appxmanifest'],
+        '10.0.0': 'package.windows10.appxmanifest'
+    }
+};
+
+var SUBSTS = ['package.phone.appxmanifest', 'package.windows.appxmanifest', 'package.windows10.appxmanifest'];
+var TARGETS = ['windows', 'phone', 'all'];
+
+function processChanges(changes) {
+    var hasManifestChanges  = changes.some(function(change) {
+        return change.target === 'package.appxmanifest';
+    });
+
+    if (!hasManifestChanges) {
+        return changes;
+    }
+
+    // Demux 'package.appxmanifest' into relevant platform-specific appx manifests.
+    // Only spend the cycles if there are version-specific plugin settings
+    var oldChanges = changes;
+    changes = [];
+
+    oldChanges.forEach(function(change) {
+        // Only support semver/device-target demux for package.appxmanifest
+        // Pass through in case something downstream wants to use it
+        if (change.target !== 'package.appxmanifest') {
+            changes.push(change);
+            return;
+        }
+
+        var manifestsForChange = getManifestsForChange(change);
+        changes = changes.concat(demuxChangeWithSubsts(change, manifestsForChange));
+    });
+
+    return changes;
+}
+
+function demuxChangeWithSubsts(change, manifestFiles) {
+    return manifestFiles.map(function(file) {
+         return createReplacement(file, change);
+    });
+}
+
+function getManifestsForChange(change) {
+    var hasTarget = (typeof change.deviceTarget !== 'undefined');
+    var hasVersion = (typeof change.versions !== 'undefined');
+
+    var targetDeviceSet = hasTarget ? change.deviceTarget : 'all';
+
+    if (TARGETS.indexOf(targetDeviceSet) === -1) {
+        // target-device couldn't be resolved, fix it up here to a valid value
+        targetDeviceSet = 'all';
+    }
+
+    // No semver/device-target for this config-file, pass it through
+    if (!(hasTarget || hasVersion)) {
+        return SUBSTS;
+    }
+
+    var knownWindowsVersionsForTargetDeviceSet = Object.keys(MANIFESTS[targetDeviceSet]);
+    return knownWindowsVersionsForTargetDeviceSet.reduce(function(manifestFiles, winver) {
+        if (hasVersion && !semver.satisfies(winver, change.versions)) {
+            return manifestFiles;
+        }
+        return manifestFiles.concat(MANIFESTS[targetDeviceSet][winver]);
+    }, []);
+}
+
+// This is a local function that creates the new replacement representing the
+// mutation.  Used to save code further down.
+function createReplacement(manifestFile, originalChange) {
+    var replacement = {
+        target:         manifestFile,
+        parent:         originalChange.parent,
+        after:          originalChange.after,
+        xmls:           originalChange.xmls,
+        versions:       originalChange.versions,
+        deviceTarget:   originalChange.deviceTarget
+    };
+    return replacement;
+}
+
+
+/*
+A class for holidng the information currently stored in plugin.xml
+It's inherited from cordova-common's PluginInfo class
+In addition it overrides getConfigFiles method to use windows-specific logic
+ */
+function PluginInfo(dirname) {
+    //  We're not using `util.inherit' because original PluginInfo defines
+    //  its' methods inside of constructor
+    CommonPluginInfo.apply(this, arguments);
+    var parentGetConfigFiles = this.getConfigFiles;
+    var parentGetEditConfigs = this.getEditConfigs;
+
+    this.getEditConfigs = function(platform) {
+        var editConfigs = parentGetEditConfigs(platform);
+        return processChanges(editConfigs);
+    };
+
+    this.getConfigFiles = function(platform) {
+        var configFiles = parentGetConfigFiles(platform);
+        return processChanges(configFiles);
+    };
+}
+
+exports.PluginInfo = PluginInfo;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### What does this PR do?
This PR moves windows-specific logic from cordova-common to cordova-windows. This logic is associated with demuxing 'package.appxmanifest' into relevant platform-specific appx manifests. Also auto-test was moved and edited according changes. 

### What testing has been done on this change?
Auto test

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

