### PR TITLE
CB-12071 Fix for CB-11825 breaks usage of InProcessServer in Cordova …

### DIFF
--- a/spec/unit/fixtures/org.test.plugins.extensionsplugin/plugin.xml
+++ b/spec/unit/fixtures/org.test.plugins.extensionsplugin/plugin.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright 2013 Anis Kadri
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.test.plugins.extensionsplugin"
+    version="1.0.0">
+
+    <!-- new requirement: NO SPACES -->
+    <name>extensionsplugin</name>
+    <!-- These are going to be required by plugman-registry -->
+    <description>my description</description>
+    <author>Jackson Badman</author>
+    <keywords>extensions,plugin</keywords>
+    <license>BSD</license>
+    <!-- end plugman-registry requirements -->
+
+    <!-- windows -->
+    <platform name="windows">
+        <config-file target="package.windows.appxmanifest" parent="/Package">
+            <Extensions>
+                <Extension Category="windows.activatableClass.inProcessServer">
+                    <InProcessServer>
+                        <Path>Foo.dll</Path>
+                        <ActivatableClass ActivatableClassId="Foo.Class" ThreadingModel="both" />
+                    </InProcessServer>
+                </Extension>
+            </Extensions>
+        </config-file>
+
+        <resource-file src="src/windows/Foo.dll" target="Foo.dll" />
+    </platform>
+
+</plugin>


### PR DESCRIPTION
…Windows
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Adds a test for missing InProcessServer extension case to prevent further breakages

### What testing has been done on this change?
Run npm test, checked that None package action breaks the test.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.