### PR TITLE
CB-12124: Make available device capabilities in package.windows10.appxmanifest

### DIFF
--- a/spec/unit/ConfigChanges.spec.js
+++ b/spec/unit/ConfigChanges.spec.js
@@ -159,5 +159,43 @@ describe('Capabilities within package.windows.appxmanifest', function() {
             done();
         });
     });
+
+    it('should be added as DeviceCapabilities when install plugin', function(done) {
+        function isDeviceCapability(capability) {
+            return capability.type === 'DeviceCapability';
+        }
+
+        function checkCapabilitiesAfterInstall(manifest) {
+            //  There is the one default capability in manifest with 'internetClient' name
+            var manifestCapabilities = getManifestCapabilities(manifest);
+            var pluginCapabilities = getPluginCapabilities(dummyPluginInfo);
+
+            expect(manifestCapabilities.length).toBe(pluginCapabilities.length + 1);
+
+            var manifestDeviceCapabilties = manifestCapabilities.filter(isDeviceCapability);
+            expect(manifestDeviceCapabilties.length).toBe(1);
+        }
+
+        function checkCapabilitiesAfterRemove(manifest) {
+            var manifestCapabilities = getManifestCapabilities(manifest);
+            expect(manifestCapabilities.length).toBe(1);
+        }
+
+        api.addPlugin(dummyPluginInfo)
+        .then(function() {
+            checkCapabilitiesAfterInstall(windowsManifest);
+            checkCapabilitiesAfterInstall(windowsManifest10);
+            api.removePlugin(dummyPluginInfo);
+        })
+        .then(function() {
+            checkCapabilitiesAfterRemove(windowsManifest);
+            checkCapabilitiesAfterRemove(windowsManifest10);
+        })
+        .catch(fail)
+        .finally(function() {
+            expect(fail).not.toHaveBeenCalled();
+            done();
+        });
+    });
 });
 

--- a/spec/unit/fixtures/org.test.plugins.capabilityplugin/plugin.xml
+++ b/spec/unit/fixtures/org.test.plugins.capabilityplugin/plugin.xml
@@ -8,5 +8,6 @@
         <Capability Name="enterpriseAuthentication" />
         <Capability Name="privateNetworkClientServer" />
         <Capability Name="sharedUserCertificates" />
+        <DeviceCapability Name="webcam"/>
     </config-file>
 </plugin>

--- a/template/cordova/lib/ConfigChanges.js
+++ b/template/cordova/lib/ConfigChanges.js
@@ -136,7 +136,7 @@ function compareCapabilities(firstCap, secondCap) {
 function generateUapCapabilities(capabilities) {
 
     function hasCapabilityChange(change) {
-        return /^\s*<Capability\s/.test(change.xml);
+        return /^\s*<(Device)?Capability\s/.test(change.xml);
     }
 
     function createPrefixedCapabilityChange(change) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### What does this PR do?
This PR makes available to use device capabilities in package.windows10.appxmanifest.

### What testing has been done on this change?
Auto test

### Checklist
- [x]  [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
