### PR TITLE
CB-12147: (windows) Fix typo in verbose output

### DIFF
--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -288,7 +288,7 @@ function buildTargets(allMsBuildVersions, config) {
     if (!msbuild) {
         return Q.reject(new CordovaError('No valid MSBuild was detected for the selected target.'));
     }
-    events.emit('vebose', 'Using MSBuild v' + msbuild.version + ' from ' + msbuild.path);
+    events.emit('verbose', 'Using MSBuild v' + msbuild.version + ' from ' + msbuild.path);
     var myBuildTargets = filterSupportedTargets(selectedBuildTargets, msbuild);
 
     var buildConfigs = [];


### PR DESCRIPTION
### Platforms affected
Windows

### What does this PR do?
Fixes a typo that reduced the verbose output

### What testing has been done on this change?
I checked that with the correct event name the line is printed in verbose mode

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

Fixing a typo in an event.