### PR TITLE
CB-11751 'extendedSplashScreen' is undefined

### DIFF
--- a/cordova-js-src/splashscreen.js
+++ b/cordova-js-src/splashscreen.js
@@ -210,7 +210,7 @@ function show() {
     positionControls();
 
     // Once the extended splash screen is setup, apply the CSS style that will make the extended splash screen visible.
-    WinJS.Utilities.removeClass(extendedSplashScreen, 'hidden');
+    WinJS.Utilities.removeClass(splashElement, 'hidden');
 }
 
 function positionControls() {
@@ -253,7 +253,7 @@ function updateImageLocation() {
 
 // Checks whether the extended splash screen is visible and returns a boolean.
 function isVisible() {
-    return !(WinJS.Utilities.hasClass(extendedSplashScreen, 'hidden'));
+    return !(WinJS.Utilities.hasClass(splashElement, 'hidden'));
 }
 
 function fadeOut(el, duration, finishCb) {
@@ -273,13 +273,21 @@ function fadeOut(el, duration, finishCb) {
 function hide() {
     if (isVisible()) {
         var hideFinishCb = function () {
-            WinJS.Utilities.addClass(extendedSplashScreen, 'hidden');
-            extendedSplashScreen.style.opacity = 1;
+            WinJS.Utilities.addClass(splashElement, 'hidden');
+            splashElement.style.opacity = 1;
             enableUserInteraction();
         }
 
+        // https://issues.apache.org/jira/browse/CB-11751
+        // This can occur when we directly replace whole document.body f.e. in a router.
+        // Note that you should disable the splashscreen in this case or update a container element instead.
+        if (document.getElementById(splashElement.id) == null) {
+            hideFinishCb();
+            return;
+        }
+
         if (fadeSplashScreen) {
-            fadeOut(extendedSplashScreen, fadeSplashScreenDuration, hideFinishCb);
+            fadeOut(splashElement, fadeSplashScreenDuration, hideFinishCb);
         } else {
             hideFinishCb();
         }

--- a/template/www/cordova.js
+++ b/template/www/cordova.js
@@ -2066,7 +2066,7 @@ function show() {
     positionControls();
 
     // Once the extended splash screen is setup, apply the CSS style that will make the extended splash screen visible.
-    WinJS.Utilities.removeClass(extendedSplashScreen, 'hidden');
+    WinJS.Utilities.removeClass(splashElement, 'hidden');
 }
 
 function positionControls() {
@@ -2109,7 +2109,7 @@ function updateImageLocation() {
 
 // Checks whether the extended splash screen is visible and returns a boolean.
 function isVisible() {
-    return !(WinJS.Utilities.hasClass(extendedSplashScreen, 'hidden'));
+    return !(WinJS.Utilities.hasClass(splashElement, 'hidden'));
 }
 
 function fadeOut(el, duration, finishCb) {
@@ -2129,13 +2129,21 @@ function fadeOut(el, duration, finishCb) {
 function hide() {
     if (isVisible()) {
         var hideFinishCb = function () {
-            WinJS.Utilities.addClass(extendedSplashScreen, 'hidden');
-            extendedSplashScreen.style.opacity = 1;
+            WinJS.Utilities.addClass(splashElement, 'hidden');
+            splashElement.style.opacity = 1;
             enableUserInteraction();
         }
 
+        // https://issues.apache.org/jira/browse/CB-11751
+        // This can occur when we directly replace whole document.body f.e. in a router.
+        // Note that you should disable the splashscreen in this case or update a container element instead.
+        if (document.getElementById(splashElement.id) == null) {
+            hideFinishCb();
+            return;
+        }
+
         if (fadeSplashScreen) {
-            fadeOut(extendedSplashScreen, fadeSplashScreenDuration, hideFinishCb);
+            fadeOut(splashElement, fadeSplashScreenDuration, hideFinishCb);
         } else {
             hideFinishCb();
         }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### What does this PR do?
[Jira issue](https://issues.apache.org/jira/browse/CB-11751)
Replaced element implicit calls by id to variable usage.
Don't fade out if splash element has been removed.

### What testing has been done on this change?
Manual and auto tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

