### PR TITLE
CB-12193 cordova.js crashes windows app if there is no CoreWindow

### DIFF
--- a/cordova-js-src/platform.js
+++ b/cordova-js-src/platform.js
@@ -27,7 +27,6 @@ module.exports = {
             channel = cordova.require('cordova/channel'),
             platform = require('cordova/platform'),
             modulemapper = require('cordova/modulemapper'),
-            configHelper = require('cordova/confighelper'),
             utils = require('cordova/utils');
 
         modulemapper.clobbers('cordova/exec/proxy', 'cordova.commandProxy');
@@ -41,7 +40,8 @@ module.exports = {
 
         var onWinJSReady = function () {
             var app = WinJS.Application,
-                splashscreen = require('cordova/splashscreen');
+                splashscreen = require('cordova/splashscreen'),
+                configHelper = require('cordova/confighelper');
 
             modulemapper.clobbers('cordova/splashscreen', 'navigator.splashscreen');
 
@@ -94,13 +94,22 @@ module.exports = {
                 }));
             };
 
-            app.addEventListener("checkpoint", checkpointHandler);
-            app.addEventListener("activated", activationHandler, false);
-            Windows.UI.WebUI.WebUIApplication.addEventListener("resuming", resumingHandler, false);
+            // CB-12193 CoreWindow and some WinRT APIs are not available in webview
+            var isCoreWindowAvailable = false;
+            try {
+                Windows.UI.ViewManagement.ApplicationView.getForCurrentView();
+                isCoreWindowAvailable = true;
+            } catch (e) { }
 
-            injectBackButtonHandler();
+            if (isCoreWindowAvailable) {
+                app.addEventListener("checkpoint", checkpointHandler);
+                app.addEventListener("activated", activationHandler, false);
+                Windows.UI.WebUI.WebUIApplication.addEventListener("resuming", resumingHandler, false);
 
-            app.start();
+                injectBackButtonHandler();
+
+                app.start();
+            }
         };
 
         function appendScript(scriptElem, loadedCb) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Don't subscribe to WinRT lifecycle events if Cordova is running in webview.
Also made confighelper to load after WinJS as it depends on it.
[CB-12193](https://issues.apache.org/jira/browse/CB-12193)

### What testing has been done on this change?
Manual tests.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

