### PR TITLE
CB-12239 Add buildFlag option similar to iOS

### DIFF
--- a/template/cordova/build
+++ b/template/cordova/build
@@ -49,6 +49,7 @@ if(['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) >= 
     console.log('    --packageThumbprint         : Thumbprint associated with the certificate.');
     console.log('    --publisherId               : Sets publisher id field in manifest.');
     console.log('    --buildConfig               : Sets build settings from configuration file.');
+    console.log('    --buildFlag                 : Sets build flag to pass to MSBuild (can be specified multiple times)');
     console.log('');
     console.log('examples:');
     console.log('    build ');
@@ -59,6 +60,7 @@ if(['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) >= 
     console.log('    build --packageCertificateKeyFile="CordovaApp_TemporaryKey.pfx"');
     console.log('    build --publisherId="CN=FakeCorp, C=US"');
     console.log('    build --buildConfig="build.json"');
+    console.log('    build --buildFlag="/clp:Verbosity=normal" --buildFlag="/p:myBuildProperty=Foo"');
     console.log('');
 
     process.exit(0);
@@ -71,7 +73,8 @@ var buildOpts = nopt({
     'debug' : Boolean,
     'release' : Boolean,
     'nobuild': Boolean,
-    'buildConfig' : path
+    'buildConfig' : path,
+    'buildFlag': [String, Array]
 }, { d : '--verbose', r: '--release' });
 
 // Make buildOptions compatible with PlatformApi build method spec

--- a/template/cordova/lib/MSBuildTools.js
+++ b/template/cordova/lib/MSBuildTools.js
@@ -29,7 +29,7 @@ function MSBuildTools (version, path) {
     this.path = path;
 }
 
-MSBuildTools.prototype.buildProject = function(projFile, buildType, buildarch, otherConfigProperties) {
+MSBuildTools.prototype.buildProject = function(projFile, buildType, buildarch, buildFlags) {
     events.emit('log', 'Building project: ' + projFile);
     events.emit('log', '\tConfiguration : ' + buildType);
     events.emit('log', '\tPlatform      : ' + buildarch);
@@ -46,11 +46,8 @@ MSBuildTools.prototype.buildProject = function(projFile, buildType, buildarch, o
     '/p:Configuration=' + buildType,
     '/p:Platform=' + buildarch];
 
-    if (otherConfigProperties) {
-        var keys = Object.keys(otherConfigProperties);
-        keys.forEach(function(key) {
-            args.push('/p:' + key + '=' + otherConfigProperties[key]);
-        });
+    if (buildFlags) {
+        args = args.concat(buildFlags);
     }
 
     var that = this;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### What does this PR do?

This PR adds `buildFlag` CLI argument and corresponding option for `build.json` file (similar to iOS) to allow users to pass arbitrary options directly to MSBuild


### What testing has been done on this change?

Added new tests, ran unit and e2e tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

