### PR TITLE
CB-12298 [Windows] bundle.appxupload not generated for Windows 10 target

### DIFF
--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -102,4 +102,16 @@ describe('Cordova create and build', function(){
             done();
         });
     });
+
+    it('spec.6 should build Windows 8.1 project bundle appxupload', function(){
+        shell.exec(buildScriptPath + ' --release --win --bundle --archs=\"x64 x86 arm\"', {silent : true});
+        var packages = shell.ls(appPackagesFolder);
+        expect(packages.filter(function(file) { return file.match(/.*bundle\.appxupload$/); }).length > 0).toBeTruthy();
+    });
+
+    it('spec.7 should build Windows 10 project bundle appxupload', function(){
+        shell.exec(buildScriptPath + ' --release --win --appx=uap --bundle --archs=\"x64 x86 arm\"', {silent : true});
+        var packages = shell.ls(appPackagesFolder);
+        expect(packages.filter(function(file) { return file.match(/.*bundle\.appxupload$/); }).length > 0).toBeTruthy();
+    });
 });

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -342,6 +342,11 @@ function buildTargets(allMsBuildVersions, config) {
                 // Only add the CordovaBundlePlatforms argument when on the last build step
                 var bundleArchs = (index === configsArray.length - 1) ? bundleTerms : build.arch;
                 otherProperties.push('/p:CordovaBundlePlatforms=' + bundleArchs);
+
+                // https://issues.apache.org/jira/browse/CB-12298
+                if (config.targetProject === 'windows10') {
+                    otherProperties.push('/p:UapAppxPackageBuildMode=StoreUpload');
+                }
             }
 
             return msbuild.buildProject(path.join(ROOT, build.target), config.buildType,  build.arch, otherProperties);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Adds a MSBuild flag to get appxupload generated for Windows 10 release builds.

### What testing has been done on this change?
Auto and manual tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
