### PR TITLE
CB-12018 : updated tests to work with jasmine instead of jasmine-node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ Thumbs.db
 node_modules/.bin
 node_modules/istanbul/
 node_modules/jasmine-node/
+node_modules/jasmine/
+node_modules/jasmine-core/
 node_modules/jshint/
 node_modules/rewire/
 node_modules/align-text/

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   ],
   "scripts": {
     "test": "npm run jshint && npm run test-unit && npm run test-e2e",
-    "test-unit": "jasmine-node --captureExceptions spec/unit",
-    "test-e2e": "jasmine-node --captureExceptions spec/e2e",
-    "cover": "istanbul cover --root template --print detail node_modules/jasmine-node/bin/jasmine-node -- spec/unit",
+    "test-unit": "jasmine --captureExceptions ",
+    "test-e2e": "jasmine --captureExceptions spec/e2e/endtoend.spec.js",
+    "cover": "istanbul cover --root bin/templates/cordova --print detail jasmine",
     "jshint": "jshint bin && jshint template && jshint spec"
   },
   "dependencies": {
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "istanbul": "^0.4.0",
-    "jasmine-node": "1.14.5",
+    "jasmine": "^2.5.3",
     "jshint": "^2.8.0",
     "rewire": "^2.5.1"
   },

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -85,7 +85,7 @@ describe('Cordova create and build', function(){
         api.locations.www = path.join(projectFolder, 'www');
 
         var fail = jasmine.createSpy('fail')
-        .andCallFake(function (err) {
+        .and.callFake(function (err) {
             console.error(err);
         });
 

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,8 @@
+{
+    "spec_dir": "spec",
+    "spec_files": [
+        "../spec/unit/**/*[sS]pec.js"
+    ],
+    "stopSpecOnExpectationFailure": false,
+    "random": false
+}

--- a/spec/unit/AppxManifest.spec.js
+++ b/spec/unit/AppxManifest.spec.js
@@ -38,7 +38,7 @@ describe('AppxManifest', function () {
 
     beforeEach(function () {
         var parseElementtreeSyncOrig = xml.parseElementtreeSync;
-        spyOn(xml, 'parseElementtreeSync').andCallFake(function (manifestPath) {
+        spyOn(xml, 'parseElementtreeSync').and.callFake(function (manifestPath) {
             return XMLS[manifestPath] || parseElementtreeSyncOrig(manifestPath);
         });
 
@@ -47,21 +47,21 @@ describe('AppxManifest', function () {
 
     describe('constructor', function () {
 
-        it('should create a new AppxManifest instance', function () {
+        it('Test #000 : should create a new AppxManifest instance', function () {
             var manifest;
             expect(function () { manifest = new AppxManifest(WINDOWS_MANIFEST); }).not.toThrow();
             expect(manifest instanceof AppxManifest).toBe(true);
         });
 
-        it('should throw if first parameter is not a file', function () {
+        it('Test #001 : should throw if first parameter is not a file', function () {
             expect(function () { new AppxManifest('/invalid/path'); }).toThrow();
         });
 
-        it('should throw if first parameter is not a valid manifest file (no "Package" tag)', function () {
+        it('Test #002 : should throw if first parameter is not a valid manifest file (no "Package" tag)', function () {
             expect(function () { new AppxManifest('/invalid/manifest'); }).toThrow();
         });
 
-        it('should add ":" to manifest prefix if needed', function () {
+        it('Test #003 : should add ":" to manifest prefix if needed', function () {
             expect(new AppxManifest(WINDOWS_MANIFEST, 'prefix').prefix).toEqual('prefix:');
         });
     });
@@ -71,20 +71,20 @@ describe('AppxManifest', function () {
             AppxManifest.__set__('manifestCache', { a: 'foo/a', b: 'foo/b', c: 'foo/c' });
         });
 
-        it('should remove all entries when no parameter is specified', function () {
+        it('Test #004 : should remove all entries when no parameter is specified', function () {
             AppxManifest.purgeCache();
             var cache = AppxManifest.__get__('manifestCache');
             expect(Object.keys(cache).length).toBe(0);
         });
 
-        it('should remove an entry when parameter is a string key', function () {
+        it('Test #005 : should remove an entry when parameter is a string key', function () {
             AppxManifest.purgeCache('a');
             var cache = AppxManifest.__get__('manifestCache');
             expect(Object.keys(cache).length).toBe(2);
             expect(cache.a).not.toBeDefined();
         });
 
-        it('should remove multiple entries when parameter is an array of keys', function () {
+        it('Test #006 : should remove multiple entries when parameter is an array of keys', function () {
             AppxManifest.purgeCache(['a', 'b']);
             var cache = AppxManifest.__get__('manifestCache');
             expect(Object.keys(cache).length).toBe(1);
@@ -92,7 +92,7 @@ describe('AppxManifest', function () {
             expect(cache.b).not.toBeDefined();
         });
 
-        it('should not remove anything if there is no such key', function () {
+        it('Test #007 : should not remove anything if there is no such key', function () {
             AppxManifest.purgeCache(['bar']);
             var cache = AppxManifest.__get__('manifestCache');
             expect(Object.keys(cache).length).toBe(3);
@@ -104,16 +104,16 @@ describe('AppxManifest', function () {
 
     describe('static get() method', function () {
 
-        it('should return an AppxManifest instance', function () {
+        it('Test #008 : should return an AppxManifest instance', function () {
             expect(AppxManifest.get(WINDOWS_MANIFEST) instanceof AppxManifest).toBe(true);
         });
 
-        it('should detect manifest prefix based on "Package" element attributes', function () {
+        it('Test #009 : should detect manifest prefix based on "Package" element attributes', function () {
             expect(AppxManifest.get(WINDOWS_MANIFEST).prefix).toEqual('m2:');
             expect(AppxManifest.get(WINDOWS_PHONE_MANIFEST).prefix).toEqual('m3:');
         });
 
-        it('should instantiate either AppxManifest or Windows 10 AppxManifest based on manifest prefix', function () {
+        it('Test #010 : should instantiate either AppxManifest or Windows 10 AppxManifest based on manifest prefix', function () {
             expect(AppxManifest.get('/no/prefixed').prefix).toEqual('');
             expect(AppxManifest.get('/no/prefixed') instanceof AppxManifest).toBe(true);
             expect(AppxManifest.get('/no/prefixed') instanceof Win10AppxManifest).toBe(false);
@@ -122,32 +122,32 @@ describe('AppxManifest', function () {
             expect(AppxManifest.get('/uap/prefixed') instanceof Win10AppxManifest).toBe(true);
         });
 
-        it('should cache AppxManifest instances by default', function () {
+        it('Test #011 : should cache AppxManifest instances by default', function () {
             var manifest  = AppxManifest.get('/no/prefixed');
-            expect(xml.parseElementtreeSync.calls.length).toBe(2);
+            expect(xml.parseElementtreeSync.calls.count()).toBe(2);
 
             var manifest2 = AppxManifest.get('/no/prefixed');
-            expect(xml.parseElementtreeSync.calls.length).toBe(2);
+            expect(xml.parseElementtreeSync.calls.count()).toBe(2);
 
             expect(manifest).toBe(manifest2);
         });
 
-        it('should not use cache to get AppxManifest instances when "ignoreCache" is specified', function () {
+        it('Test #012 : should not use cache to get AppxManifest instances when "ignoreCache" is specified', function () {
             var manifest  = AppxManifest.get('/no/prefixed');
-            expect(xml.parseElementtreeSync.calls.length).toBe(2);
+            expect(xml.parseElementtreeSync.calls.count()).toBe(2);
 
             var manifest2 = AppxManifest.get('/no/prefixed', true);
-            expect(xml.parseElementtreeSync.calls.length).toBe(4);
+            expect(xml.parseElementtreeSync.calls.count()).toBe(4);
 
             expect(manifest).not.toBe(manifest2);
         });
 
-        it('should not cache AppxManifest instances when "ignoreCache" is specified', function () {
+        it('Test #013 : should not cache AppxManifest instances when "ignoreCache" is specified', function () {
             var manifest  = AppxManifest.get('/no/prefixed', true);
-            expect(xml.parseElementtreeSync.calls.length).toBe(2);
+            expect(xml.parseElementtreeSync.calls.count()).toBe(2);
 
             var manifest2 = AppxManifest.get('/no/prefixed');
-            expect(xml.parseElementtreeSync.calls.length).toBe(4);
+            expect(xml.parseElementtreeSync.calls.count()).toBe(4);
 
             expect(manifest).not.toBe(manifest2);
         });
@@ -156,7 +156,7 @@ describe('AppxManifest', function () {
     describe('instance get* methods', function () {
         var methods = ['getPhoneIdentity','getIdentity','getProperties','getApplication','getVisualElements'];
 
-        it('should exists', function () {
+        it('Test #014 : should exists', function () {
             var manifest = AppxManifest.get(WINDOWS_PHONE_MANIFEST);
             var emptyManifest = AppxManifest.get('/no/prefixed');
 
@@ -171,7 +171,7 @@ describe('AppxManifest', function () {
     });
 
     describe('instance write method', function () {
-        it('should not write duplicate UAP capability declarations', function () {
+        it('Test #015 : should not write duplicate UAP capability declarations', function () {
             var manifest = AppxManifest.get(WINDOWS_10_MANIFEST);
             var capabilities = manifest.doc.find('.//Capabilities');
             capabilities.append(new et.Element('uap:Capability', { 'Name': 'enterpriseAuthentication' }));
@@ -184,11 +184,11 @@ describe('AppxManifest', function () {
     });
 
     describe('getVisualElements methods', function () {
-        it('refineColor should leave CSS color name as is', function () {
+        it('Test #016 : refineColor should leave CSS color name as is', function () {
             expect(refineColor(CSS_COLOR_NAME)).toEqual(CSS_COLOR_NAME);
         });
 
-        it('setForegroundText should change the ForegroundText property on non-Windows 10 platforms', function () {
+        it('Test #017 : setForegroundText should change the ForegroundText property on non-Windows 10 platforms', function () {
             var visualElementsWindows = AppxManifest.get(WINDOWS_MANIFEST).getVisualElements();
             var visualElementsWindows10 = AppxManifest.get(WINDOWS_10_MANIFEST).getVisualElements();
 
@@ -213,7 +213,7 @@ describe('AppxManifest', function () {
             expect(visualElementsWindows10.getForegroundText()).toEqual(undefined);
         });
 
-        it('getSplashScreenExtension/setSplashScreenExtension', function () {
+        it('Test #018 : getSplashScreenExtension/setSplashScreenExtension', function () {
             var visualElementsWindows = AppxManifest.get(WINDOWS_MANIFEST).getVisualElements();
             var visualElementsWindows10 = AppxManifest.get(WINDOWS_10_MANIFEST).getVisualElements();
             var visualElementsWindowsPhone = AppxManifest.get(WINDOWS_PHONE_MANIFEST).getVisualElements();

--- a/spec/unit/ConfigChanges.spec.js
+++ b/spec/unit/ConfigChanges.spec.js
@@ -53,7 +53,7 @@ describe('PlatformMunger', function () {
             { before: undefined, count: 1, xml: '<DummyElement name="Dummy" />'}
         ]}};
         munger = new PlatformMunger('windows', tempDir);
-        spyOn(BaseMunger.prototype, 'apply_file_munge').andCallThrough();
+        spyOn(BaseMunger.prototype, 'apply_file_munge').and.callThrough();
     });
 
     afterEach(function () {
@@ -122,7 +122,7 @@ describe('Capabilities within package.windows.appxmanifest', function() {
     }
 
     var fail = jasmine.createSpy('fail')
-    .andCallFake(function (err) {
+    .and.callFake(function (err) {
         console.error(err);
     });
 

--- a/spec/unit/JsprojManager.spec.js
+++ b/spec/unit/JsprojManager.spec.js
@@ -43,9 +43,9 @@ describe('JsprojManager', function () {
 
         JsprojManager.__set__('proj', jasmine.createSpy('proj'));
 
-        spyOn(shell, 'ls').andReturn([PROJECT_PATH + '/CordovaApp.projitems']);
-        spyOn(xml, 'parseElementtreeSync').andReturn(FAKE_MANIFEST);
-        spyOn(AppxManifest, 'get').andCallThrough();
+        spyOn(shell, 'ls').and.returnValue([PROJECT_PATH + '/CordovaApp.projitems']);
+        spyOn(xml, 'parseElementtreeSync').and.returnValue(FAKE_MANIFEST);
+        spyOn(AppxManifest, 'get').and.callThrough();
 
         project = JsprojManager.getProject(PROJECT_PATH);
     });
@@ -55,7 +55,7 @@ describe('JsprojManager', function () {
     });
 
     it('should throw if project is not a windows project', function () {
-        shell.ls.andCallThrough();
+        shell.ls.and.callThrough();
         expect(function () {
             JsprojManager.getProject(INVALID_PROJECT_PATH);
         }).toThrow();
@@ -65,6 +65,6 @@ describe('JsprojManager', function () {
         expect(project.getPackageName()).toBe('HelloCordova');
         expect(AppxManifest.get).toHaveBeenCalled();
         // Should pass 'ignoreCache' option to 'get' method
-        expect(AppxManifest.get.calls[0].args[1]).toBe(true);
+        expect(AppxManifest.get.calls.argsFor(0)[1]).toBe(true);
     });
 });

--- a/spec/unit/MSBuildTools.spec.js
+++ b/spec/unit/MSBuildTools.spec.js
@@ -106,7 +106,7 @@ describe('checkMSBuildVersion method', function(){
     it('spec.6 should return valid version and path', function(){
         var version  = '14.0';
 
-        spawnSpy.andReturn(Q.resolve(
+        spawnSpy.and.returnValue(Q.resolve(
             '\r\nHKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\MSBuild\\ToolsVersions\\12.0\r\n\t' +
             'MSBuildToolsPath\tREG_SZ\t' + fakeToolsPath(version) + '\r\n\r\n')
         );
@@ -118,7 +118,7 @@ describe('checkMSBuildVersion method', function(){
     });
 
     it('spec.7 should return null if no tools found for version', function(){
-        spawnSpy.andReturn(Q.resolve('ERROR: The system was unable to find the specified registry key or value.'));
+        spawnSpy.and.returnValue(Q.resolve('ERROR: The system was unable to find the specified registry key or value.'));
 
         checkMSBuildVersion('14.0').then(function (actual) {
             expect(actual).not.toBeDefined();
@@ -126,7 +126,7 @@ describe('checkMSBuildVersion method', function(){
     });
 
     it('spec.8 should return null on internal error', function(){
-        spawnSpy.andReturn(Q.reject());
+        spawnSpy.and.returnValue(Q.reject());
 
         checkMSBuildVersion('14.0').then(function (actual) {
             expect(actual).not.toBeDefined();
@@ -156,8 +156,8 @@ describe('getAvailableUAPVersions method', function(){
     var programFilesOrig = process.env['ProgramFiles'];
 
     beforeEach(function () {
-        shellTest = spyOn(shell, 'test').andReturn(true);
-        shellLs = spyOn(shell, 'ls').andReturn(availableVersions);
+        shellTest = spyOn(shell, 'test').and.returnValue(true);
+        shellLs = spyOn(shell, 'ls').and.returnValue(availableVersions);
         process.env['ProgramFiles(x86)'] = '/';
         process.env['ProgramFiles'] = '/';
     });
@@ -174,9 +174,9 @@ describe('getAvailableUAPVersions method', function(){
     });
 
     it('should return empty array if no UAP SDKs installed', function() {
-        shellLs.andReturn([]);
+        shellLs.and.returnValue([]);
         expect(buildTools.getAvailableUAPVersions().length).toEqual(0);
-        shellTest.andReturn(false);
+        shellTest.and.returnValue(false);
         expect(buildTools.getAvailableUAPVersions().length).toEqual(0);
     });
 
@@ -188,7 +188,7 @@ describe('getAvailableUAPVersions method', function(){
 
     it('should return sorted list versions with only valid versions', function() {
         var brokenAvailableVersions = availableVersions.concat('Broken.version');
-        shellLs.andReturn(brokenAvailableVersions);
+        shellLs.and.returnValue(brokenAvailableVersions);
 
         var versions = buildTools.getAvailableUAPVersions();
         expect(versions).toEqual(jasmine.any(Array));
@@ -222,7 +222,7 @@ describe('getMSBuildToolsAt method', function () {
     });
 
     it('should return MSBuildTools instance', function (done) {
-        spawnSpy.andReturn(Q(fakeVersion));
+        spawnSpy.and.returnValue(Q(fakeVersion));
 
         buildTools.getMSBuildToolsAt(fakePath)
         .then(function (tools) {
@@ -237,7 +237,7 @@ describe('getMSBuildToolsAt method', function () {
     });
 
     it('should reject promise if no msbuild found', function (done) {
-        spawnSpy.andReturn(Q.reject());
+        spawnSpy.and.returnValue(Q.reject());
 
         buildTools.getMSBuildToolsAt(messyPath)
         .then(success, fail)

--- a/spec/unit/Prepare.Win10.spec.js
+++ b/spec/unit/Prepare.Win10.spec.js
@@ -200,7 +200,7 @@ describe('A Windows 10 project should warn if it supports remote mode and restri
         mockConfig = createMockConfigAndManifestForApplyAccessRules(true, 'http://www.bing.com/*');
         addCapabilityDeclarationToMockManifest(mockConfig.manifest, 'documentsLibrary');
 
-        spyOn(AppxManifest, 'get').andReturn(mockConfig.manifest);
+        spyOn(AppxManifest, 'get').and.returnValue(mockConfig.manifest);
 
         stringFound = false;
         events.on('warn', function (msg) {
@@ -242,7 +242,7 @@ function createMockConfigAndManifestForApplyAccessRules(isWin10) {
     '</widget>\n';
 
     var origParseElementtreeSync = xml.parseElementtreeSync;
-    spyOn(xml, 'parseElementtreeSync').andCallFake(function(path) {
+    spyOn(xml, 'parseElementtreeSync').and.callFake(function(path) {
         if (path ==='config.xml') return new et.ElementTree(et.XML(TEST_XML));
         return origParseElementtreeSync(path);
     });
@@ -250,7 +250,7 @@ function createMockConfigAndManifestForApplyAccessRules(isWin10) {
     var config = new ConfigParser('config.xml');
 
     var origGetPreference = config.getPreference;
-    spyOn(config, 'getPreference').andCallFake(function (prefName) {
+    spyOn(config, 'getPreference').and.callFake(function (prefName) {
         if (prefName === 'WindowsDefaultUriPrefix') {
             return isWin10 ? 'ms-appx-web://' : 'ms-appx://';
         }
@@ -468,8 +468,8 @@ describe('copyIcons method', function () {
 
     function createMockConfig(images, splashScreens) {
         var result = jasmine.createSpyObj('config', ['getIcons', 'getSplashScreens']);
-        result.getIcons.andReturn(images);
-        result.getSplashScreens.andReturn(splashScreens || []);
+        result.getIcons.and.returnValue(images);
+        result.getSplashScreens.and.returnValue(splashScreens || []);
 
         return result;
     }
@@ -506,7 +506,7 @@ describe('copyIcons method', function () {
         events.on('warn', warnSpy);
         copyImages(project, locations);
         expect(FileUpdater.updatePaths).toHaveBeenCalledWith({}, { rootDir: PROJECT }, logFileOp);
-        expect(warnSpy.calls[0].args[0]).toMatch('image was skipped');
+        expect(warnSpy.calls.argsFor(0)[0]).toMatch('image was skipped');
     });
 
     describe('when "target" attribute is specified for the image', function () {
@@ -524,7 +524,7 @@ describe('copyIcons method', function () {
                 'Square44x44.targetsize-16.jpg'
             ];
 
-            spyOn(fs, 'readdirSync').andReturn(matchingFiles.concat(nonMatchingFiles));
+            spyOn(fs, 'readdirSync').and.returnValue(matchingFiles.concat(nonMatchingFiles));
 
             var images = [{src: 'res/Windows/Square44x44.png', target: 'SmallIcon' }];
             var project = { projectConfig: createMockConfig(images), root: PROJECT };
@@ -564,9 +564,9 @@ describe('copyIcons method', function () {
         var splashScreensFiles = splashScreens.map(function(splash) {
             return path.basename(splash.src);
         });
-        spyOn(fs, 'readdirSync').andReturn(splashScreensFiles);
+        spyOn(fs, 'readdirSync').and.returnValue(splashScreensFiles);
 
-        spyOn(fs, 'statSync').andReturn({
+        spyOn(fs, 'statSync').and.returnValue({
             size: size300K
         });
 
@@ -580,7 +580,7 @@ describe('copyIcons method', function () {
         expectedPathMap['images' + path.sep + 'SplashScreenPhone.scale-240.png'] = path.join('res', 'Windows', 'splashscreenphone.scale-240.png');
         expectedPathMap['images' + path.sep + 'SplashScreenPhone.scale-100.png'] = path.join('res', 'Windows', 'splashscreenphone.png');
         expect(FileUpdater.updatePaths).toHaveBeenCalledWith(expectedPathMap, { rootDir: PROJECT }, logFileOp);
-        expect(warnSpy.calls[0].args[0]).toMatch('file size exceeds the limit');
+        expect(warnSpy.calls.argsFor(0)[0]).toMatch('file size exceeds the limit');
     });
 
     it('should ignore splashScreens with unsupported extensions and emit a warning', function () {
@@ -596,9 +596,9 @@ describe('copyIcons method', function () {
         var splashScreensFiles = splashScreens.map(function(splash) {
             return path.basename(splash.src);
         });
-        spyOn(fs, 'readdirSync').andReturn(splashScreensFiles);
+        spyOn(fs, 'readdirSync').and.returnValue(splashScreensFiles);
 
-        spyOn(fs, 'statSync').andReturn({
+        spyOn(fs, 'statSync').and.returnValue({
             size: 0
         });
 
@@ -610,15 +610,15 @@ describe('copyIcons method', function () {
         var extensionNotSupportedMsg = 'extension is not supported';
         var expectedPathMap = {};
         expect(FileUpdater.updatePaths).toHaveBeenCalledWith(expectedPathMap, { rootDir: PROJECT }, logFileOp);
-        expect(warnSpy.calls[0].args[0]).toMatch(extensionNotSupportedMsg);
-        expect(warnSpy.calls[1].args[0]).toMatch(extensionNotSupportedMsg);
-        expect(warnSpy.calls[2].args[0]).toMatch(extensionNotSupportedMsg);
+        expect(warnSpy.calls.argsFor(0)[0]).toMatch(extensionNotSupportedMsg);
+        expect(warnSpy.calls.argsFor(1)[0]).toMatch(extensionNotSupportedMsg);
+        expect(warnSpy.calls.argsFor(2)[0]).toMatch(extensionNotSupportedMsg);
     });
 
     it('should warn about mixed splashscreen extensions used for non-MRT syntax', function () {
         var updateSplashScreenImageExtensions = prepare.__get__('updateSplashScreenImageExtensions');
         spyOn(fs, 'writeFileSync');
-        spyOn(AppxManifest, 'get').andReturn({
+        spyOn(AppxManifest, 'get').and.returnValue({
             getVisualElements: function() {
                 return {
                     getSplashScreenExtension: function() {
@@ -644,9 +644,9 @@ describe('copyIcons method', function () {
         var splashScreensFiles = splashScreens.map(function(splash) {
             return path.basename(splash.src);
         });
-        spyOn(fs, 'readdirSync').andReturn(splashScreensFiles);
+        spyOn(fs, 'readdirSync').and.returnValue(splashScreensFiles);
 
-        spyOn(fs, 'statSync').andReturn({
+        spyOn(fs, 'statSync').and.returnValue({
             size: 0
         });
 
@@ -656,8 +656,8 @@ describe('copyIcons method', function () {
         updateSplashScreenImageExtensions(project, locations);
 
         var mixedExtensionsMsg = 'splash screens have mixed file extensions';
-        expect(warnSpy.calls[0].args[0]).toMatch(mixedExtensionsMsg);
-        expect(warnSpy.calls[1].args[0]).toMatch(mixedExtensionsMsg);
+        expect(warnSpy.calls.argsFor(0)[0]).toMatch(mixedExtensionsMsg);
+        expect(warnSpy.calls.argsFor(1)[0]).toMatch(mixedExtensionsMsg);
     });
 
     it('should update manifests with proper splashscreen image extension', function () {
@@ -672,7 +672,7 @@ describe('copyIcons method', function () {
             win81Manifest = AppxManifest.get(Win81ManifestPath),
             wp81Manifest = AppxManifest.get(WP81ManifestPath);
 
-        spyOn(AppxManifest, 'get').andCallFake(function(manifestPath) {
+        spyOn(AppxManifest, 'get').and.callFake(function(manifestPath) {
             if (manifestPath.indexOf(Win10ManifestName) !== -1) {
                 return win10Manifest;
             }
@@ -695,9 +695,9 @@ describe('copyIcons method', function () {
         var splashScreensFiles = splashScreens.map(function(splash) {
             return path.basename(splash.src);
         });
-        spyOn(fs, 'readdirSync').andReturn(splashScreensFiles);
+        spyOn(fs, 'readdirSync').and.returnValue(splashScreensFiles);
 
-        spyOn(fs, 'statSync').andReturn({
+        spyOn(fs, 'statSync').and.returnValue({
             size: 0
         });
 

--- a/spec/unit/Version.spec.js
+++ b/spec/unit/Version.spec.js
@@ -21,7 +21,7 @@ var Version = require('../../template/cordova/lib/Version.js');
 
 describe('Version constructor', function () {
 
-    it('should behave correctly', function () {
+    it('Test #000 : should behave correctly', function () {
         var v1 = new Version(1);
         expect(v1.major).toBe(1);
         expect(v1.minor).toBe(0);
@@ -47,13 +47,15 @@ describe('Version constructor', function () {
 
 describe('Version parse functions work as expected.', function() {
 
-    var version = Version.fromString('1.2.4.7');
-    expect(version.major).toBe(1);
-    expect(version.minor).toBe(2);
-    expect(version.build).toBe(4);
-    expect(version.qfe).toBe(7);
+    it('Test #001 : should behave correctly', function() {
+        var version = Version.fromString('1.2.4.7');
+        expect(version.major).toBe(1);
+        expect(version.minor).toBe(2);
+        expect(version.build).toBe(4);
+        expect(version.qfe).toBe(7);
+    });
 
-    it('should parse incomplete version string.', function() {
+    it('Test #002 : should parse incomplete version string.', function() {
         var version = Version.fromString('1.5.3');
         expect(version.major).toBe(1);
         expect(version.minor).toBe(5);
@@ -61,7 +63,7 @@ describe('Version parse functions work as expected.', function() {
         expect(version.qfe).toBe(0);
     });
 
-    it('should produce an error as the version string is invalid', function() {
+    it('Test #003 : should produce an error as the version string is invalid', function() {
         try {
             Version.fromString('This is invalid.');
 
@@ -72,7 +74,7 @@ describe('Version parse functions work as expected.', function() {
         }
     });
 
-    it('should produce an error as the string is too long.', function() {
+    it('Test #004 : should produce an error as the string is too long.', function() {
         try {
             Version.fromString('1.5.3.2.7');
 
@@ -81,63 +83,63 @@ describe('Version parse functions work as expected.', function() {
         catch (ex) {
             expect(ex.constructor).toBe(RangeError);
         }
+        expect(Version.tryParse('This is invalid')).toBe(false);
     });
-
-    expect(Version.tryParse('This is invalid')).toBe(false);
-
 });
 
 describe('Version equality functions work as expected.', function() {
+    it('Test #005 : should parse incomplete version string.', function() {
+        var v1Base = new Version(1, 1, 2, 3);
+        // equal to v1Base
+        var v1Copy = new Version(1, 1, 2, 3);
+        // greater than v1Base by QFE
+        var gtV1ByQfe = new Version(1, 1, 2, 4);
+        // greater than v1Base by Build
+        var gtV1ByBuild = new Version(1, 1, 3, 3);
+        // greater than v1Base by Minor
+        var gtV1ByMinor = new Version(1, 2, 2, 3);
+        // greater than v1Base by Major
+        var gtV1ByMajor = new Version(2, 1, 2, 3);
 
-    var v1Base = new Version(1, 1, 2, 3);
-    // equal to v1Base
-    var v1Copy = new Version(1, 1, 2, 3);
-    // greater than v1Base by QFE
-    var gtV1ByQfe = new Version(1, 1, 2, 4);
-    // greater than v1Base by Build
-    var gtV1ByBuild = new Version(1, 1, 3, 3);
-    // greater than v1Base by Minor
-    var gtV1ByMinor = new Version(1, 2, 2, 3);
-    // greater than v1Base by Major
-    var gtV1ByMajor = new Version(2, 1, 2, 3);
+        expect(v1Copy.eq(v1Base)).toBe(true);
+        expect(v1Copy.gte(v1Base)).toBe(true);
+        expect(v1Copy.gt(v1Base)).toBe(false);
 
-    expect(v1Copy.eq(v1Base)).toBe(true);
-    expect(v1Copy.gte(v1Base)).toBe(true);
-    expect(v1Copy.gt(v1Base)).toBe(false);
+        expect(gtV1ByQfe.eq(v1Base)).toBe(false);
+        expect(gtV1ByQfe.gte(v1Base)).toBe(true);
+        expect(gtV1ByQfe.gt(v1Base)).toBe(true);
 
-    expect(gtV1ByQfe.eq(v1Base)).toBe(false);
-    expect(gtV1ByQfe.gte(v1Base)).toBe(true);
-    expect(gtV1ByQfe.gt(v1Base)).toBe(true);
+        expect(gtV1ByBuild.eq(v1Base)).toBe(false);
+        expect(gtV1ByBuild.gte(v1Base)).toBe(true);
+        expect(gtV1ByBuild.gt(v1Base)).toBe(true);
 
-    expect(gtV1ByBuild.eq(v1Base)).toBe(false);
-    expect(gtV1ByBuild.gte(v1Base)).toBe(true);
-    expect(gtV1ByBuild.gt(v1Base)).toBe(true);
+        expect(gtV1ByMinor.eq(v1Base)).toBe(false);
+        expect(gtV1ByMinor.gte(v1Base)).toBe(true);
+        expect(gtV1ByMinor.gt(v1Base)).toBe(true);
 
-    expect(gtV1ByMinor.eq(v1Base)).toBe(false);
-    expect(gtV1ByMinor.gte(v1Base)).toBe(true);
-    expect(gtV1ByMinor.gt(v1Base)).toBe(true);
-
-    expect(gtV1ByMajor.eq(v1Base)).toBe(false);
-    expect(gtV1ByMajor.gte(v1Base)).toBe(true);
-    expect(gtV1ByMajor.gt(v1Base)).toBe(true);
+        expect(gtV1ByMajor.eq(v1Base)).toBe(false);
+        expect(gtV1ByMajor.gte(v1Base)).toBe(true);
+        expect(gtV1ByMajor.gt(v1Base)).toBe(true);
+    });
 });
 
 describe('Version equality tests integrate with Array sort and toString() as expected.', function() {
+    it('Test #006 : should parse incomplete version string.', function() {
+        var v1Base = new Version(1, 1, 2, 3);
+        // equal to v1Base
+        var v1Copy = new Version(1, 1, 2, 3);
+        // greater than v1Base by QFE
+        var gtV1ByQfe = new Version(1, 1, 2, 4);
+        // greater than v1Base by Build
+        var gtV1ByBuild = new Version(1, 1, 3, 3);
+        // greater than v1Base by Minor
+        var gtV1ByMinor = new Version(1, 2, 2, 3);
+        // greater than v1Base by Major
+        var gtV1ByMajor = new Version(2, 1, 2, 3);
 
-    var v1Base = new Version(1, 1, 2, 3);
-    // equal to v1Base
-    var v1Copy = new Version(1, 1, 2, 3);
-    // greater than v1Base by QFE
-    var gtV1ByQfe = new Version(1, 1, 2, 4);
-    // greater than v1Base by Build
-    var gtV1ByBuild = new Version(1, 1, 3, 3);
-    // greater than v1Base by Minor
-    var gtV1ByMinor = new Version(1, 2, 2, 3);
-    // greater than v1Base by Major
-    var gtV1ByMajor = new Version(2, 1, 2, 3);
+        var toTest = [gtV1ByBuild, gtV1ByMajor, v1Copy, gtV1ByMinor, gtV1ByQfe, v1Base];
+        toTest.sort(Version.comparer);
 
-    var toTest = [gtV1ByBuild, gtV1ByMajor, v1Copy, gtV1ByMinor, gtV1ByQfe, v1Base];
-    toTest.sort(Version.comparer);
-
-    expect(toTest.join(',')).toBe('1.1.2.3,1.1.2.3,1.1.2.4,1.1.3.3,1.2.2.3,2.1.2.3');
+        expect(toTest.join(',')).toBe('1.1.2.3,1.1.2.3,1.1.2.4,1.1.3.3,1.2.2.3,2.1.2.3');
+    });
 });

--- a/spec/unit/WindowsConfigParser.spec.js
+++ b/spec/unit/WindowsConfigParser.spec.js
@@ -40,13 +40,13 @@ describe('getAllMinMaxUAPVersions method', function () {
 
     var mockConfig;
     beforeEach(function () {
-        spyOn(xml, 'parseElementtreeSync').andReturn(new et.ElementTree(et.XML(TEST_XML)));
+        spyOn(xml, 'parseElementtreeSync').and.returnValue(new et.ElementTree(et.XML(TEST_XML)));
 
         mockConfig = new ConfigParser('/some/file');
     });
 
     it('should correctly transform all versions as a baseline.', function() {
-        spyOn(mockConfig, 'getMatchingPreferences').andReturn([
+        spyOn(mockConfig, 'getMatchingPreferences').and.returnValue([
             { name: 'Windows.Universal-MinVersion', value: '10.0.9910.0' },
             { name: 'Windows.Universal-MaxVersionTested', value: '10.0.9917.0' },
             { name: 'Windows.Desktop-MinVersion', value: '10.0.9910.0' },
@@ -73,7 +73,7 @@ describe('getAllMinMaxUAPVersions method', function () {
     });
 
     it('should produce versions correctly even when the config file has no settings.', function() {
-        spyOn(mockConfig, 'getMatchingPreferences').andReturn([]);
+        spyOn(mockConfig, 'getMatchingPreferences').and.returnValue([]);
 
         var versionSet = mockConfig.getAllMinMaxUAPVersions();
         var verBaseline = rewire('../../template/cordova/lib/ConfigParser')
@@ -88,7 +88,7 @@ describe('getAllMinMaxUAPVersions method', function () {
 
     it('should fail with a RangeError if version specified incorrectly', function() {
         spyOn(mockConfig, 'getMatchingPreferences')
-        .andReturn([
+        .and.returnValue([
             { name: 'Windows.Universal-MinVersion', value: '10.0.9910.f' },
             { name: 'Windows.Universal-MaxVersionTested', value: '10.0.9917.0' },
         ]);

--- a/spec/unit/build.spec.js
+++ b/spec/unit/build.spec.js
@@ -84,17 +84,17 @@ describe('run method', function() {
         configParserOriginal = build.__get__('ConfigParser');
 
         var originalBuildMethod = build.run;
-        spyOn(build, 'run').andCallFake(function () {
+        spyOn(build, 'run').and.callFake(function () {
             // Bind original build to custom 'this' object to mock platform's locations property
             return originalBuildMethod.apply({locations: {www: 'some/path'}}, arguments);
         });
 
-        spyOn(utils, 'isCordovaProject').andReturn(true);
+        spyOn(utils, 'isCordovaProject').and.returnValue(true);
         spyOn(prepare, 'applyPlatformConfig');
         spyOn(prepare, 'updateBuildConfig');
-        spyOn(package, 'getPackage').andReturn(Q({}));
+        spyOn(package, 'getPackage').and.returnValue(Q({}));
 
-        spyOn(AppxManifest, 'get').andReturn({
+        spyOn(AppxManifest, 'get').and.returnValue({
             getIdentity: function () {
                 return  { setPublisher: function () {} };
             },
@@ -113,7 +113,7 @@ describe('run method', function() {
             buildSpy = jasmine.createSpy();
 
         // utils.isCordovaProject is a spy, so we can call andReturn directly on it
-        utils.isCordovaProject.andReturn(false);
+        utils.isCordovaProject.and.returnValue(false);
         createFindAllAvailableVersionsMock([{version: '14.0', buildProject: buildSpy, path: testPath }]);
 
         build.run([ 'node', buildPath, '--release', '--debug' ])
@@ -153,10 +153,8 @@ describe('run method', function() {
         build.run({ buildConfig: buildConfigPath })
         .finally(function() {
             expect(prepare.updateBuildConfig).toHaveBeenCalled();
-
-            var buildOpts = prepare.updateBuildConfig.calls[0].args[0];
+            var buildOpts = prepare.updateBuildConfig.calls.argsFor(0)[0];
             var buildConfig = require(buildConfigPath).windows.debug;
-
             expect(buildOpts.packageCertificateKeyFile).toBeDefined();
             expect(buildOpts.packageCertificateKeyFile)
                 .toEqual(path.resolve(path.dirname(buildConfigPath), buildConfig.packageCertificateKeyFile));
@@ -165,13 +163,15 @@ describe('run method', function() {
                 expect(buildOpts[key]).toBeDefined();
                 expect(buildOpts[key]).toEqual(buildConfig[key]);
             });
-
+            done();
+        }).fail(function err (errMsg) {
+            expect(errMsg).toBeUndefined();
             done();
         });
-    });
+    }, 20000);
 
     it('spec.4 should call buildProject of MSBuildTools with buildType = "release" if called with --release argument', function(done) {
-        var buildSpy = jasmine.createSpy().andCallFake(function (solutionFile, buildType, buildArch) {
+        var buildSpy = jasmine.createSpy().and.callFake(function (solutionFile, buildType, buildArch) {
             expect(buildType).toBe('release');
         });
 
@@ -185,7 +185,7 @@ describe('run method', function() {
     });
 
     it('spec.5 should call buildProject of MSBuildTools with buildType = "debug" if called without arguments', function(done) {
-        var buildSpy = jasmine.createSpy().andCallFake(function (solutionFile, buildType, buildArch) {
+        var buildSpy = jasmine.createSpy().and.callFake(function (solutionFile, buildType, buildArch) {
             expect(buildType).toBe('debug');
         });
 
@@ -199,7 +199,7 @@ describe('run method', function() {
     });
 
     it('spec.6 should call buildProject of MSBuildTools with buildArch = "arm" if called with --archs="arm" argument', function(done) {
-        var buildSpy = jasmine.createSpy().andCallFake(function (solutionFile, buildType, buildArch) {
+        var buildSpy = jasmine.createSpy().and.callFake(function (solutionFile, buildType, buildArch) {
             expect(buildArch).toBe('arm');
         });
 
@@ -338,7 +338,7 @@ describe('run method', function() {
     });
 
     it('spec.13 should be able to override target via --appx parameter', function(done) {
-        var buildSpy = jasmine.createSpy().andCallFake(function(solutionFile, buildType, buildArch) {
+        var buildSpy = jasmine.createSpy().and.callFake(function(solutionFile, buildType, buildArch) {
                 // check that we build Windows 10 and not Windows 8.1
                 expect(solutionFile.toLowerCase()).toMatch('cordovaapp.windows10.jsproj');
             });
@@ -361,10 +361,10 @@ describe('run method', function() {
         process.env.VSINSTALLDIR = customMSBuildPath;
 
         spyOn(MSBuildTools, 'getMSBuildToolsAt')
-            .andReturn(Q({
+            .and.returnValue(Q({
                 path: customMSBuildPath,
                 version: customMSBuildVersion,
-                buildProject: jasmine.createSpy('buildProject').andReturn(Q())
+                buildProject: jasmine.createSpy('buildProject').and.returnValue(Q())
             }));
 
         var fail = jasmine.createSpy('fail');
@@ -409,7 +409,7 @@ describe('buildFlags', function () {
         });
 
         it('should handle build flags from both CLI and buildConfig.json', function () {
-            readFileSync.andReturn(JSON.stringify({
+            readFileSync.and.returnValue(JSON.stringify({
                 windows: { debug: { buildFlag: 'baz="quux"' } }
             }));
 
@@ -423,12 +423,12 @@ describe('buildFlags', function () {
 
     describe('build', function () {
         beforeEach(function () {
-            spyOn(utils, 'isCordovaProject').andReturn(true);
+            spyOn(utils, 'isCordovaProject').and.returnValue(true);
             spyOn(prepare, 'applyPlatformConfig');
             spyOn(prepare, 'updateBuildConfig');
-            spyOn(package, 'getPackage').andReturn(Q({}));
+            spyOn(package, 'getPackage').and.returnValue(Q({}));
 
-            spyOn(AppxManifest, 'get').andReturn({
+            spyOn(AppxManifest, 'get').and.returnValue({
                 getIdentity: function () {
                     return  { setPublisher: function () {} };
                 },
@@ -438,7 +438,7 @@ describe('buildFlags', function () {
 
         it('should pass buildFlags directly to MSBuild', function(done) {
             var fail = jasmine.createSpy('fail');
-            var buildTools = {version: '14.0', buildProject: jasmine.createSpy('buildProject').andReturn(Q()), path: testPath };
+            var buildTools = {version: '14.0', buildProject: jasmine.createSpy('buildProject').and.returnValue(Q()), path: testPath };
             var buildOptions = {
                 argv: ['--buildFlag', 'foo=bar']
             };

--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -35,12 +35,12 @@ describe('check_reqs module', function () {
             Requirement = check_reqs.__get__('Requirement');
         });
 
-        it('that should be constructable', function () {
+        it('Test #000 : that should be constructable', function () {
             var requirement = new Requirement('someId', 'Some Name');
             expect(requirement instanceof Requirement).toBeTruthy();
         });
 
-        it('that should have fields defined', function () {
+        it('Test #001 : that should have fields defined', function () {
             var requirement = new Requirement('someId', 'Some Name');
             expect(requirement.id).toBe('someId');
             expect(requirement.name).toBe('Some Name');
@@ -75,11 +75,11 @@ describe('check_reqs module', function () {
 
             checkSpy = jasmine.createSpy('checkSpy');
             fakeCheckFns = [
-                checkSpy.andReturn(Q('1.0')),
-                checkSpy.andReturn(Q('2.0')),
-                checkSpy.andReturn(Q('3.0'))
+                checkSpy.and.returnValue(Q('1.0')),
+                checkSpy.and.returnValue(Q('2.0')),
+                checkSpy.and.returnValue(Q('3.0'))
             ];
-            spyOn(xml, 'parseElementtreeSync').andReturn(new et.ElementTree(et.XML(TEST_XML)));
+            spyOn(xml, 'parseElementtreeSync').and.returnValue(new et.ElementTree(et.XML(TEST_XML)));
             fakeConfig = new ConfigParser('/some/file');
         });
 
@@ -89,7 +89,7 @@ describe('check_reqs module', function () {
             check_reqs.__set__('config', originalconfig);
         });
 
-        it('that should return a promise, fulfilled with an array of Requirements', function (done) {
+        it('Test #002 : that should return a promise, fulfilled with an array of Requirements', function (done) {
             check_reqs.__set__('requirements', fakeRequirements);
             check_reqs.__set__('checkFns', fakeCheckFns);
             check_reqs.__set__('config', fakeConfig);
@@ -106,7 +106,7 @@ describe('check_reqs module', function () {
             });
         });
 
-        it('that should not reject if one of requirements is not installed', function  (done) {
+        it('Test #003 : that should not reject if one of requirements is not installed', function  (done) {
             check_reqs.__set__('requirements', fakeRequirements);
             fakeCheckFns[0] = function () { return Q.reject('Error message'); };
             check_reqs.__set__('checkFns', fakeCheckFns);
@@ -124,9 +124,9 @@ describe('check_reqs module', function () {
             });
         });
 
-        it('that should reject if one of checks has internal erorrs', function  (done) {
+        it('Test #004 : that should reject if one of checks has internal erorrs', function  (done) {
             check_reqs.__set__('requirements', fakeRequirements);
-            fakeCheckFns[0] = checkSpy.andThrow('Fatal error');
+            fakeCheckFns[0] = checkSpy.and.throwError('Fatal error');
             check_reqs.__set__('checkFns', fakeCheckFns);
             check_reqs.__set__('config', fakeConfig);
 
@@ -136,15 +136,15 @@ describe('check_reqs module', function () {
                 done();
             })
             .catch(function  (error) {
-                expect(error).toBe('Fatal error');
+                expect(error).toMatch('Fatal error');
                 done();
             });
         });
 
-        it('that should not run other requirements checks if `fatal` requirement isn\'t installed', function  (done) {
+        it('Test #005 : that should not run other requirements checks if `fatal` requirement isn\'t installed', function  (done) {
             check_reqs.__set__('requirements', fakeRequirements);
             // The second requirement is fatal, so we're setting up second check to fail
-            fakeCheckFns[1] = checkSpy.andReturn(Q.reject('Error message'));
+            fakeCheckFns[1] = checkSpy.and.returnValue(Q.reject('Error message'));
             check_reqs.__set__('checkFns', fakeCheckFns);
             check_reqs.__set__('config', fakeConfig);
 
@@ -152,7 +152,7 @@ describe('check_reqs module', function () {
             .then(function (requirements) {
                 expect(requirements.length).toBe(2);
                 expect(requirements[1].isFatal).toBeTruthy();
-                expect(checkSpy.calls.length).toBe(2);
+                expect(checkSpy.calls.count()).toBe(2);
                 done();
             })
             .catch(function  (error) {

--- a/spec/unit/clean.spec.js
+++ b/spec/unit/clean.spec.js
@@ -12,12 +12,12 @@ describe('Cordova clean command', function() {
         iconPath = path.join(currentProject, 'images/SplashScreen.scale-100.png');
 
         var fsExistsSyncOrig = fs.existsSync;
-        spyOn(fs, 'existsSync').andCallFake(function (filePath) {
+        spyOn(fs, 'existsSync').and.callFake(function (filePath) {
             if (/config\.xml$/.test(filePath)) return true;
             return fsExistsSyncOrig(filePath);
         });
         var fsStatSyncOrig = fs.statSync;
-        spyOn(fs, 'statSync').andCallFake(function (filePath) {
+        spyOn(fs, 'statSync').and.callFake(function (filePath) {
             if (/SplashScreen\.scale-100\.png$/.test(filePath)) {
                 // Use absolute path:
                 return fsStatSyncOrig(iconPath);
@@ -42,7 +42,7 @@ describe('Cordova clean command', function() {
             }
         };
 
-        var rejected = jasmine.createSpy().andCallFake(function(err) {
+        var rejected = jasmine.createSpy().and.callFake(function(err) {
             // Log error:
             expect(err).not.toBeDefined();
         });

--- a/spec/unit/deployment.spec.js
+++ b/spec/unit/deployment.spec.js
@@ -43,14 +43,14 @@ describe('The correct version of the app deployment tool is obtained.', function
         }
     });
 
-    it('Provides an AppDeployCmdTool when 8.1 is requested.', function() {
+    it('Test #000 : Provides an AppDeployCmdTool when 8.1 is requested.', function() {
 
         var tool = deployment.getDeploymentTool('8.1');
         expect(tool instanceof AppDeployCmdTool).toBe(true);
 
     });
 
-    it('Provides a WinAppDeployCmdTool when 10.0 is requested.', function() {
+    it('Test #001 : Provides a WinAppDeployCmdTool when 10.0 is requested.', function() {
 
         var tool = deployment.getDeploymentTool('10.0');
         expect(tool instanceof WinAppDeployCmdTool).toBe(true);
@@ -98,66 +98,55 @@ describe('Windows 10 deployment interacts with the file system as expected.', fu
         }
     });
 
-    it('enumerateDevices returns a valid set of objects', function() {
+    it('Test #002 : enumerateDevices returns a valid set of objects', function(done) {
         var deploymentTool = deployment.getDeploymentTool('10.0');
-        var done = false;
-        deploymentTool.enumerateDevices().then(function(deviceList) {
-
+        deploymentTool.enumerateDevices()
+        .then(function(deviceList) {
             expect(deviceList.length).toBe(3);
             expect(deviceList[0].name).toBe('Lumia 1520 (RM-940)');
             expect(deviceList[0].index).toBe(0);
             expect(deviceList[0].type).toBe('device');
-
-            done = true;
-
+            done();
+        }).fail(function err (errMsg) {
+            expect(errMsg).toBeUndefined();
+            done();
         });
-
-        waitsFor(function() { return done; });
     });
 
-    it('installAppPackage passes the correct set of parameters', function() {
+    it('Test #003 : installAppPackage passes the correct set of parameters', function(done) {
         var deploymentTool = deployment.getDeploymentTool('10.0');
-        var done = false;
-        deploymentTool.enumerateDevices().then(function(deviceList) {
-            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ false).then(function() {
-
-                // expect() calls are in the fakeSpawn function
-                done = true;
-
-            });
+        deploymentTool.enumerateDevices()
+        .then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ false);
+            done();
+        }).fail(function err (errMsg) {
+            expect(errMsg).toBeUndefined();
+            done();
         });
-
-        waitsFor(function() { return done; });
     });
 
-    it('installAppPackage passes the correct set of parameters when updating', function() {
+    it('Test #004 : installAppPackage passes the correct set of parameters when updating', function(done) {
         var deploymentTool = deployment.getDeploymentTool('10.0');
-        var done = false;
-        deploymentTool.enumerateDevices().then(function(deviceList) {
-            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ true).then(function() {
-
-                // expect() calls are in the fakeSpawn function
-                done = true;
-
-            });
+        deploymentTool.enumerateDevices()
+        .then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ true);
+            done();
+        }).fail(function err (errMsg) {
+            expect(errMsg).toBeUndefined();
+            done();
         });
-
-        waitsFor(function() { return done; });
     });
 
-    it('uninstallAppPackage passes the correct set of parameters', function() {
+    it('Test #005 : uninstallAppPackage passes the correct set of parameters', function(done) {
         var deploymentTool = deployment.getDeploymentTool('10.0');
-        var done = false;
-        deploymentTool.enumerateDevices().then(function(deviceList) {
-            deploymentTool.uninstallAppPackage(TEST_APP_PACKAGE_ID, deviceList[2]).then(function() {
-
-                // expect() calls are in the fakeSpawn function
-                done = true;
-
-            });
+        deploymentTool.enumerateDevices()
+        .then(function(deviceList) {
+            deploymentTool.uninstallAppPackage(TEST_APP_PACKAGE_ID, deviceList[2]);
+            done();
+        }).fail(function err (errMsg) {
+            expect(errMsg).toBeUndefined();
+            done();
         });
-
-        waitsFor(function() { return done; });
     });
 });
 
@@ -206,93 +195,81 @@ describe('Windows 8.1 deployment interacts with the file system as expected.', f
         }
     });
 
-    it('enumerateDevices returns a valid set of objects', function() {
+    it('Test #006 : enumerateDevices returns a valid set of objects', function(done) {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        var done = false;
-        deploymentTool.enumerateDevices().then(function(deviceList) {
-
+        deploymentTool.enumerateDevices()
+        .then(function(deviceList) {
             expect(deviceList.length).toBe(12);
             expect(deviceList[0].name).toBe('Device');
             expect(deviceList[0].index).toBe(0);
             expect(deviceList[0].type).toBe('device');
-
             expect(deviceList[5].name).toBe('Mobile Emulator 10.0.10150.0 1080p 6 inch 2GB');
             expect(deviceList[5].index).toBe(5);
             expect(deviceList[5].type).toBe('emulator');
-
-            done = true;
-
+            done();
+        }).fail(function err (errMsg) {
+            expect(errMsg).toBeUndefined();
+            done();
         });
-        waitsFor(function() { return done; });
     });
 
-    it('installAppPackage passes the correct set of parameters', function() {
+    it('Test #007 : installAppPackage passes the correct set of parameters', function(done) {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        var done = false;
-        deploymentTool.enumerateDevices().then(function(deviceList) {
-            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ false).then(function() {
-
-                // expect() calls are in the fakeSpawn function
-                done = true;
-
-            });
+        deploymentTool.enumerateDevices()
+        .then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ false);
+            done();
+        }).fail(function err (errMsg) {
+            expect(errMsg).toBeUndefined();
+            done();
         });
-        waitsFor(function() { return done; });
     });
 
-    it('installAppPackage passes the correct set of parameters when updating', function() {
+    it('Test #008 : installAppPackage passes the correct set of parameters when updating', function(done) {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        var done = false;
-        deploymentTool.enumerateDevices().then(function(deviceList) {
-            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ true).then(function() {
-
-                // expect() calls are in the fakeSpawn function
-                done = true;
-
-            });
+        deploymentTool.enumerateDevices()
+        .then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ false, /*shouldUpdate*/ true);
+            done();
+        }).fail(function err (errMsg) {
+            expect(errMsg).toBeUndefined();
+            done();
         });
-        waitsFor(function() { return done; });
     });
 
-    it('installAppPackage passes the correct set of parameters when launching', function() {
+    it('Test #009 : installAppPackage passes the correct set of parameters when launching', function(done) {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        var done = false;
-        deploymentTool.enumerateDevices().then(function(deviceList) {
-            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ true, /*shouldUpdate*/ false).then(function() {
-
-                // expect() calls are in the fakeSpawn function
-                done = true;
-
-            });
+        deploymentTool.enumerateDevices()
+        .then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ true, /*shouldUpdate*/ false);
+            done();
+        }).fail(function err (errMsg) {
+            expect(errMsg).toBeUndefined();
+            done();
         });
-        waitsFor(function() { return done; });
     });
 
-    it('installAppPackage passes the correct set of parameters when updating and launching', function() {
+    it('Test #010 : installAppPackage passes the correct set of parameters when updating and launching', function(done) {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        var done = false;
-        deploymentTool.enumerateDevices().then(function(deviceList) {
-            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ true, /*shouldUpdate*/ true).then(function() {
-
-                // expect() calls are in the fakeSpawn function
-                done = true;
-
-            });
+        deploymentTool.enumerateDevices()
+        .then(function(deviceList) {
+            deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /*shouldLaunch*/ true, /*shouldUpdate*/ true);
+            done();
+        }).fail(function err (errMsg) {
+            expect(errMsg).toBeUndefined();
+            done();
         });
-        waitsFor(function() { return done; });
     });
 
-    it('uninstallAppPackage passes the correct set of parameters', function() {
+    it('Test #011 : uninstallAppPackage passes the correct set of parameters', function(done) {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        var done = false;
-        deploymentTool.enumerateDevices().then(function(deviceList) {
-            deploymentTool.uninstallAppPackage(TEST_APP_PACKAGE_ID, deviceList[5]).then(function() {
-
-                // expect() calls are in the fakeSpawn function
-                done = true;
-
-            });
+        deploymentTool.enumerateDevices()
+        .then(function(deviceList) {
+            deploymentTool.uninstallAppPackage(TEST_APP_PACKAGE_ID, deviceList[5]);
+            done();
+       }).fail(function err (errMsg) {
+            expect(errMsg).toBeUndefined();
+            done();
         });
-        waitsFor(function() { return done; });
     });
 });

--- a/spec/unit/pluginHandler/common.spec.js
+++ b/spec/unit/pluginHandler/common.spec.js
@@ -40,12 +40,12 @@ var removeFileAndParents = common.__get__('removeFileAndParents');
 
 describe('common platform handler', function() {
     describe('copyFile', function() {
-        it('should throw if source path not found', function(){
+        it('Test #000 : should throw if source path not found', function(){
             expect(function(){copyFile('/some/dir', 'foo', project_dir, dest);})
                 .toThrow(new Error('"' + path.resolve('/some/dir', 'foo') + '" not found!'));
         });
 
-        it('should throw if src not in plugin directory', function(){
+        it('Test #001 : should throw if src not in plugin directory', function(){
             shell.mkdir('-p', project_dir);
             fs.writeFileSync(non_plugin_file, 'contents', 'utf-8');
             var outside_file = '../non_plugin_file';
@@ -54,7 +54,7 @@ describe('common platform handler', function() {
             shell.rm('-rf', test_dir);
         });
 
-        it('should allow symlink src, if inside plugin', function(){
+        it('Test #002 : should allow symlink src, if inside plugin', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 
@@ -67,7 +67,7 @@ describe('common platform handler', function() {
             shell.rm('-rf', project_dir);
         });
 
-        it('should throw if symlink is linked to a file outside the plugin', function(){
+        it('Test #003 : should throw if symlink is linked to a file outside the plugin', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(non_plugin_file, 'contents', 'utf-8');
 
@@ -81,7 +81,7 @@ describe('common platform handler', function() {
             shell.rm('-rf', project_dir);
         });
 
-        it('should throw if dest is outside the project directory', function(){
+        it('Test #004 : should throw if dest is outside the project directory', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
             expect(function(){copyFile(test_dir, java_file, project_dir, non_plugin_file);})
@@ -89,11 +89,11 @@ describe('common platform handler', function() {
             shell.rm('-rf', project_dir);
         });
 
-        it('should call mkdir -p on target path', function(){
+        it('Test #005 : should call mkdir -p on target path', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 
-            var s = spyOn(shell, 'mkdir').andCallThrough();
+            var s = spyOn(shell, 'mkdir').and.callThrough();
             copyFile(test_dir, java_file, project_dir, dest);
 
             expect(s).toHaveBeenCalled();
@@ -101,11 +101,11 @@ describe('common platform handler', function() {
             shell.rm('-rf', project_dir);
         });
 
-        it('should call cp source/dest paths', function(){
+        it('Test #006 : should call cp source/dest paths', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 
-            var s = spyOn(shell, 'cp').andCallThrough();
+            var s = spyOn(shell, 'cp').and.callThrough();
             copyFile(test_dir, java_file, project_dir, dest);
 
             expect(s).toHaveBeenCalled();
@@ -116,7 +116,7 @@ describe('common platform handler', function() {
     });
 
     describe('copyNewFile', function () {
-        it('should throw if target path exists', function(){
+        it('Test #007 : should throw if target path exists', function(){
             shell.mkdir('-p', dest);
             expect(function(){copyNewFile(test_dir, src, project_dir, dest);})
                 .toThrow(new Error('"' + dest + '" already exists!'));
@@ -125,11 +125,11 @@ describe('common platform handler', function() {
     });
 
     describe('deleteJava', function() {
-        it('should call fs.unlinkSync on the provided paths', function(){
+        it('Test #008 : should call fs.unlinkSync on the provided paths', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 
-            var s = spyOn(fs, 'unlinkSync').andCallThrough();
+            var s = spyOn(fs, 'unlinkSync').and.callThrough();
             removeFileAndParents(project_dir, java_file);
             expect(s).toHaveBeenCalled();
             expect(s).toHaveBeenCalledWith(path.resolve(project_dir, java_file));
@@ -137,7 +137,7 @@ describe('common platform handler', function() {
             shell.rm('-rf', java_dir);
         });
 
-        it('should delete empty directories after removing source code in a java src path hierarchy', function(){
+        it('Test #009 : should delete empty directories after removing source code in a java src path hierarchy', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 

--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -251,15 +251,15 @@ describe('run method', function() {
 
     it('spec.8 should accept --archs parameter either as cli or as platform arg', function(done) {
 
-        spyOn(utils, 'isCordovaProject').andReturn(true);
-        spyOn(packages, 'getPackage').andReturn(Q({ arch: 'arm' }));
-        spyOn(packages, 'deployToDesktop').andReturn(Q());
+        spyOn(utils, 'isCordovaProject').and.returnValue(true);
+        spyOn(packages, 'getPackage').and.returnValue(Q({ arch: 'arm' }));
+        spyOn(packages, 'deployToDesktop').and.returnValue(Q());
 
         var anyString = jasmine.any(String);
         var expectedDeployOptions = jasmine.objectContaining({arch: 'arm'});
 
         var fail = jasmine.createSpy('fail')
-        .andCallFake(function (err) {
+        .and.callFake(function (err) {
             console.error(err);
         });
 
@@ -284,9 +284,9 @@ describe('run method', function() {
 
     it('spec.9 should fall back to anycpu if --archs parameter is not specified', function(done) {
 
-        spyOn(utils, 'isCordovaProject').andReturn(true);
-        spyOn(packages, 'getPackage').andReturn(Q({ arch: 'anycpu' }));
-        spyOn(packages, 'deployToDesktop').andReturn(Q());
+        spyOn(utils, 'isCordovaProject').and.returnValue(true);
+        spyOn(packages, 'getPackage').and.returnValue(Q({ arch: 'anycpu' }));
+        spyOn(packages, 'deployToDesktop').and.returnValue(Q());
 
         var anyString = jasmine.any(String);
         var expectedDeployOptions = jasmine.objectContaining({arch: 'anycpu'});

--- a/template/cordova/lib/PluginInfo.js
+++ b/template/cordova/lib/PluginInfo.js
@@ -1,3 +1,22 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
 var semver = require('semver');
 var CommonPluginInfo = require('cordova-common').PluginInfo;
 


### PR DESCRIPTION
CB-12018 : updated tests to work with jasmine instead of jasmine-node

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
Uses jasmine to test instead of jasmine-node.

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
