### PR TITLE
CB-12415 Windows build fails if start page is missing

### DIFF
--- a/template/cordova/prebuild.js
+++ b/template/cordova/prebuild.js
@@ -62,6 +62,11 @@ module.exports = function patch(platform) {
     var startPageFilePath = shell.ls(path.join(__dirname, '..', startPage))[0];
     var reBaseJs = new RegExp(escapedBasejsSrcMap[platform], 'i');
 
+    if (!startPageFilePath) {
+        console.warn('Warning: Start page is missing on the disk. The build must go on but note that this will cause WACK failures.');
+        return;
+    }
+
     if (shell.grep(reBaseJs, startPageFilePath).length === 0) {
         // 3. If it doesn't - patch page to include base.js ref before cordova.js
         var appendBaseJsRe = /( *)(<script\s+(?:type="text\/javascript"\s+)?src="(.*\/)?cordova\.js">\s*<\/script>)/;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Continue the build if the start page is missing on disk.

### What testing has been done on this change?
Run npm test, manual test

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
