### PR TITLE
CB-12298 [Windows] bundle.appxupload not generated for Windows 10 target

### DIFF
--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -103,15 +103,27 @@ describe('Cordova create and build', function(){
         });
     });
 
-    it('spec.6 should build Windows 8.1 project bundle appxupload', function(){
+    it('spec.6 should generate appxupload for Windows 8.1 project bundle release build', function(){
         shell.exec(buildScriptPath + ' --release --win --bundle --archs=\"x64 x86 arm\"', {silent : true});
         var packages = shell.ls(appPackagesFolder);
         expect(packages.filter(function(file) { return file.match(/.*bundle\.appxupload$/); }).length > 0).toBeTruthy();
     });
 
-    it('spec.7 should build Windows 10 project bundle appxupload', function(){
+    it('spec.6.1 should generate appxupload for Windows 8.1 project non-bundle release build', function(){
+        shell.exec(buildScriptPath + ' --release --win --archs=\"x64 x86 arm\"', {silent : true});
+        var packages = shell.ls(appPackagesFolder);
+        expect(packages.filter(function(file) { return file.match(/.*\.appxupload$/); }).length).toBe(3);
+    });
+
+    it('spec.7 should generate appxupload for Windows 10 project bundle release build', function(){
         shell.exec(buildScriptPath + ' --release --win --appx=uap --bundle --archs=\"x64 x86 arm\"', {silent : true});
         var packages = shell.ls(appPackagesFolder);
         expect(packages.filter(function(file) { return file.match(/.*bundle\.appxupload$/); }).length > 0).toBeTruthy();
+    });
+
+    it('spec.7.1 should generate appxupload for Windows 10 project non-bundle release build', function(){
+        shell.exec(buildScriptPath + ' --release --win --appx=uap --archs=\"x64 x86 arm\"', {silent : true});
+        var packages = shell.ls(appPackagesFolder);
+        expect(packages.filter(function(file) { return file.match(/.*\.appxupload$/); }).length).toBe(3);
     });
 });

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -342,11 +342,11 @@ function buildTargets(allMsBuildVersions, config) {
                 // Only add the CordovaBundlePlatforms argument when on the last build step
                 var bundleArchs = (index === configsArray.length - 1) ? bundleTerms : build.arch;
                 otherProperties.push('/p:CordovaBundlePlatforms=' + bundleArchs);
+            }
 
-                // https://issues.apache.org/jira/browse/CB-12298
-                if (config.targetProject === 'windows10') {
-                    otherProperties.push('/p:UapAppxPackageBuildMode=StoreUpload');
-                }
+            // https://issues.apache.org/jira/browse/CB-12298
+            if (config.targetProject === 'windows10' && config.buildType === 'release') {
+                otherProperties.push('/p:UapAppxPackageBuildMode=StoreUpload');
             }
 
             return msbuild.buildProject(path.join(ROOT, build.target), config.buildType,  build.arch, otherProperties);


### PR DESCRIPTION
Generate appxupload for non-bundle builds as well

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
