### PR TITLE
CB-12987: (windows) Fix bug with the addition of hidden files to the Windows platform assembly

### DIFF
--- a/template/cordova/lib/prepare.js
+++ b/template/cordova/lib/prepare.js
@@ -766,7 +766,7 @@ function updateWww(cordovaProject, destinations) {
     events.emit(
         'verbose', 'Merging and updating files from [' + sourceDirs.join(', ') + '] to ' + targetDir);
     FileUpdater.mergeAndUpdateDir(
-        sourceDirs, targetDir, { rootDir: cordovaProject.root }, logFileOp);
+        sourceDirs, targetDir, { rootDir: cordovaProject.root, exclude: '.*' }, logFileOp);
 }
 
 /**


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Folders starting with '.' are excluded from the project

### What testing has been done on this change?
Manual testing

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
