### PR TITLE
Cb 12636 Fix check_reqs to properly find VS 2017

### DIFF
--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -94,7 +94,7 @@ function getHighestAppropriateVersion (versions, requiredVersion) {
         .sort(Version.comparer)
         .filter(function (toolVersion) {
             return toolVersion.gte(requiredVersion);
-        })[0];
+        }).reverse()[0];
 }
 
 /**
@@ -147,6 +147,12 @@ function getInstalledVSVersions () {
                     installedVersions.splice(installedVersions.indexOf('12.0'), 1);
                     return installedVersions;
                 });
+        })
+        .then(function (installedVersions) {
+            var willowVersions = MSBuildTools.getWillowInstallations().map(function (installation) {
+                return installation.version;
+            });
+            return installedVersions.concat(willowVersions);
         });
 }
 
@@ -280,6 +286,9 @@ var checkMSBuild = function (windowsTargetVersion, windowsPhoneTargetVersion) {
 var checkVS = function (windowsTargetVersion, windowsPhoneTargetVersion) {
     var vsRequiredVersion = getMinimalRequiredVersionFor('visualstudio', windowsTargetVersion, windowsPhoneTargetVersion);
 
+    if (process.env.VSINSTALLDIR) {
+        return Q('(user-specified)');
+    }
     return getInstalledVSVersions()
         .then(function (installedVersions) {
             var appropriateVersion = getHighestAppropriateVersion(installedVersions, vsRequiredVersion);


### PR DESCRIPTION
### Platforms affected
this one!

### What does this PR do?
Teaches `cordova-windows` to properly recognize VS 2017 installation in the system.

### What testing has been done on this change?
`cordova requirements` on Windows 10 / Windows 8.1 with only VS 2017, as well as with other VS versions.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
