### PR TITLE
CB-13155: Improved target parsing

### DIFF
--- a/template/cordova/lib/package.js
+++ b/template/cordova/lib/package.js
@@ -147,7 +147,10 @@ module.exports.findDevice = function (deploymentTool, target) {
             return Q.resolve(deviceList[0]);
         } else {
             var candidateList = deviceList.filter(function (device) {
-                return device.index === parseInt(target, 10);
+                var deviceIndexEqualsTarget = device.index === parseInt(target, 10);
+                var deviceNameContainsTarget = device.name.toLowerCase().indexOf(target.toLowerCase()) >= 0;
+                
+                return deviceIndexEqualsTarget || deviceNameContainsTarget;
             });
 
             if (candidateList.length > 0) {


### PR DESCRIPTION
### Platforms affected
this one

### What does this PR do?
User can now specify emulator name via `--target` arg.

### What testing has been done on this change?
Tried to deploy using "cordova run windows --target "Emulator 8.1 1080P 5.5 inch" -- --appx=8.1-phone"

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
