### PR TITLE
CB-13237 Default to UAP

### DIFF
--- a/template/cordova/lib/ConfigParser.js
+++ b/template/cordova/lib/ConfigParser.js
@@ -67,7 +67,7 @@ WindowsConfigParser.prototype.getMatchingPreferences = function (regexp) {
 WindowsConfigParser.prototype.getWindowsTargetVersion = function () {
     var preference = this.getPreference('windows-target-version');
 
-    if (!preference) { preference = '8.1'; } // default is 8.1.
+    if (!preference) { preference = 'UAP'; } // default is UAP
 
     return preference;
 };


### PR DESCRIPTION
This addresses an issue when app developers only have VS-2017 which does not include the older tooling.
UWP 'should' be the default going forward anyway.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
