### PR TITLE
CB-13422: (windows) Fix typo in build error message

### DIFF
--- a/template/cordova/lib/package.js
+++ b/template/cordova/lib/package.js
@@ -30,9 +30,9 @@ var CordovaError = require('cordova-common').CordovaError;
 // build and project types specified by script parameters
 module.exports.getPackage = function (projectType, buildtype, buildArch) {
     var appPackages = path.resolve(path.join(__dirname, '..', '..', 'AppPackages'));
-    // reject promise if apppackages folder doesn't exists
+    // reject promise if AppPackages folder doesn't exist
     if (!fs.existsSync(appPackages)) {
-        return Q.reject('AppPackages doesn\'t exists');
+        return Q.reject('AppPackages folder doesn\'t exist');
     }
     // find out and resolve paths for all folders inside AppPackages
     var pkgDirs = fs.readdirSync(appPackages).map(function (relative) {


### PR DESCRIPTION
### Platforms affected
Windows

### What does this PR do?
Fix a typo in an error message during build

### What testing has been done on this change?
none (only a string has been changed, and none of the tests expects a specific error message wording

### Checklist
- [ X ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ X ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
