### PR TITLE
CB-13641: (windows) support transparent splash screen background color.

### DIFF
--- a/cordova-js-src/splashscreen.js
+++ b/cordova-js-src/splashscreen.js
@@ -43,6 +43,7 @@ var DEFAULT_SPLASHSCREEN_DURATION = 3000, // in milliseconds
     PROGRESSRING_BOTTOM_MARGIN = 10; // needed for windows 10 min height window
 
 var bgColor = "#464646",
+    isBgColorTransparent = false,
     titleInitialBgColor,
     titleBgColor,
     autoHideSplashScreen = true,
@@ -70,10 +71,11 @@ function readPreferencesFromCfg(cfg, manifest) {
 
         bgColor = cfg.getPreferenceValue('SplashScreenBackgroundColor') || bgColor;
         bgColor = bgColor.toLowerCase().replace('0x', '#');
+        isBgColorTransparent = (bgColor === 'transparent');
 
-        if (bgColor !== 'transparent') {
+        if (!isBgColorTransparent) {
             if (bgColor.length > 7) {
-                // Remove aplha
+                // Remove alpha
                 bgColor = bgColor.slice(0, 1) + bgColor.slice(3, bgColor.length);
             }
 
@@ -215,7 +217,7 @@ function exitFullScreen() {
 // Make title bg color match splashscreen bg color
 function colorizeTitleBar() {
     var appView = Windows.UI.ViewManagement.ApplicationView.getForCurrentView();
-    if (isWin10UWP && (typeof titleBgColor !== 'undefined')) {
+    if (isWin10UWP && !isBgColorTransparent) {
         titleInitialBgColor = appView.titleBar.backgroundColor;
 
         appView.titleBar.backgroundColor = titleBgColor;
@@ -226,7 +228,7 @@ function colorizeTitleBar() {
 // Revert title bg color
 function revertTitleBarColor() {
     var appView = Windows.UI.ViewManagement.ApplicationView.getForCurrentView();
-    if (isWin10UWP && (typeof titleInitialBgColor !== 'undefined')) {
+    if (isWin10UWP && !isBgColorTransparent) {
         appView.titleBar.backgroundColor = titleInitialBgColor;
         appView.titleBar.buttonBackgroundColor = titleInitialBgColor;
     }

--- a/cordova-js-src/splashscreen.js
+++ b/cordova-js-src/splashscreen.js
@@ -69,18 +69,21 @@ function readPreferencesFromCfg(cfg, manifest) {
         splashImageSrc = schema + ':///' + manifest.getSplashScreenImagePath().replace(/\\/g, '/');
 
         bgColor = cfg.getPreferenceValue('SplashScreenBackgroundColor') || bgColor;
-        bgColor = bgColor.replace('0x', '#').replace('0X', '#');
-        if (bgColor.length > 7) {
-            // Remove aplha
-            bgColor = bgColor.slice(0, 1) + bgColor.slice(3, bgColor.length);
-        }
+        bgColor = bgColor.toLowerCase().replace('0x', '#');
 
-        titleBgColor = {
-            a: 255,
-            r: parseInt(bgColor.slice(1, 3), 16),
-            g: parseInt(bgColor.slice(3, 5), 16),
-            b: parseInt(bgColor.slice(5, 7), 16)
-        };
+        if (bgColor !== 'transparent') {
+            if (bgColor.length > 7) {
+                // Remove aplha
+                bgColor = bgColor.slice(0, 1) + bgColor.slice(3, bgColor.length);
+            }
+
+            titleBgColor = {
+                a: 255,
+                r: parseInt(bgColor.slice(1, 3), 16),
+                g: parseInt(bgColor.slice(3, 5), 16),
+                b: parseInt(bgColor.slice(5, 7), 16)
+            };
+        }
 
         autoHideSplashScreen = readBoolFromCfg('AutoHideSplashScreen', autoHideSplashScreen, cfg);
         splashScreenDelay = cfg.getPreferenceValue('SplashScreenDelay') || splashScreenDelay;
@@ -212,7 +215,7 @@ function exitFullScreen() {
 // Make title bg color match splashscreen bg color
 function colorizeTitleBar() {
     var appView = Windows.UI.ViewManagement.ApplicationView.getForCurrentView();
-    if (isWin10UWP) {
+    if (isWin10UWP && (typeof titleBgColor !== 'undefined')) {
         titleInitialBgColor = appView.titleBar.backgroundColor;
 
         appView.titleBar.backgroundColor = titleBgColor;
@@ -223,7 +226,7 @@ function colorizeTitleBar() {
 // Revert title bg color
 function revertTitleBarColor() {
     var appView = Windows.UI.ViewManagement.ApplicationView.getForCurrentView();
-    if (isWin10UWP) {
+    if (isWin10UWP && (typeof titleInitialBgColor !== 'undefined')) {
         appView.titleBar.backgroundColor = titleInitialBgColor;
         appView.titleBar.buttonBackgroundColor = titleInitialBgColor;
     }

--- a/template/www/cordova.js
+++ b/template/www/cordova.js
@@ -1879,6 +1879,7 @@
         var PROGRESSRING_BOTTOM_MARGIN = 10; // needed for windows 10 min height window
 
         var bgColor = '#464646';
+        var isBgColorTransparent = false;
         var titleInitialBgColor;
         var titleBgColor;
         var autoHideSplashScreen = true;
@@ -1906,10 +1907,11 @@
 
                 bgColor = cfg.getPreferenceValue('SplashScreenBackgroundColor') || bgColor;
                 bgColor = bgColor.toLowerCase().replace('0x', '#');
+                isBgColorTransparent = (bgColor === 'transparent');
 
-                if (bgColor !== 'transparent') {
+                if (!isBgColorTransparent) {
                     if (bgColor.length > 7) {
-                        // Remove aplha
+                        // Remove alpha
                         bgColor = bgColor.slice(0, 1) + bgColor.slice(3, bgColor.length);
                     }
 
@@ -2051,7 +2053,7 @@
         // Make title bg color match splashscreen bg color
         function colorizeTitleBar () {
             var appView = Windows.UI.ViewManagement.ApplicationView.getForCurrentView();
-            if (appView.titleBar && (typeof titleBgColor !== 'undefined')) {
+            if (appView.titleBar && !isBgColorTransparent) {
                 titleInitialBgColor = appView.titleBar.backgroundColor;
 
                 appView.titleBar.backgroundColor = titleBgColor;
@@ -2062,7 +2064,7 @@
         // Revert title bg color
         function revertTitleBarColor () {
             var appView = Windows.UI.ViewManagement.ApplicationView.getForCurrentView();
-            if (appView.titleBar && (typeof titleInitialBgColor !== 'undefined')) {
+            if (appView.titleBar && !isBgColorTransparent) {
                 appView.titleBar.backgroundColor = titleInitialBgColor;
                 appView.titleBar.buttonBackgroundColor = titleInitialBgColor;
             }

--- a/template/www/cordova.js
+++ b/template/www/cordova.js
@@ -1905,18 +1905,21 @@
                 splashImageSrc = schema + ':///' + manifest.getSplashScreenImagePath().replace(/\\/g, '/');
 
                 bgColor = cfg.getPreferenceValue('SplashScreenBackgroundColor') || bgColor;
-                bgColor = bgColor.replace('0x', '#').replace('0X', '#');
-                if (bgColor.length > 7) {
-                    // Remove aplha
-                    bgColor = bgColor.slice(0, 1) + bgColor.slice(3, bgColor.length);
-                }
+                bgColor = bgColor.toLowerCase().replace('0x', '#');
 
-                titleBgColor = {
-                    a: 255,
-                    r: parseInt(bgColor.slice(1, 3), 16),
-                    g: parseInt(bgColor.slice(3, 5), 16),
-                    b: parseInt(bgColor.slice(5, 7), 16)
-                };
+                if (bgColor !== 'transparent') {
+                    if (bgColor.length > 7) {
+                        // Remove aplha
+                        bgColor = bgColor.slice(0, 1) + bgColor.slice(3, bgColor.length);
+                    }
+
+                    titleBgColor = {
+                        a: 255,
+                        r: parseInt(bgColor.slice(1, 3), 16),
+                        g: parseInt(bgColor.slice(3, 5), 16),
+                        b: parseInt(bgColor.slice(5, 7), 16)
+                    };
+                }
 
                 autoHideSplashScreen = readBoolFromCfg('AutoHideSplashScreen', autoHideSplashScreen, cfg);
                 splashScreenDelay = cfg.getPreferenceValue('SplashScreenDelay') || splashScreenDelay;
@@ -2048,7 +2051,7 @@
         // Make title bg color match splashscreen bg color
         function colorizeTitleBar () {
             var appView = Windows.UI.ViewManagement.ApplicationView.getForCurrentView();
-            if (appView.titleBar) {
+            if (appView.titleBar && (typeof titleBgColor !== 'undefined')) {
                 titleInitialBgColor = appView.titleBar.backgroundColor;
 
                 appView.titleBar.backgroundColor = titleBgColor;
@@ -2059,7 +2062,7 @@
         // Revert title bg color
         function revertTitleBarColor () {
             var appView = Windows.UI.ViewManagement.ApplicationView.getForCurrentView();
-            if (appView.titleBar) {
+            if (appView.titleBar && (typeof titleInitialBgColor !== 'undefined')) {
                 appView.titleBar.backgroundColor = titleInitialBgColor;
                 appView.titleBar.buttonBackgroundColor = titleInitialBgColor;
             }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
windows

### What does this PR do?
adds support for transparent splash screen background color.

### What testing has been done on this change?
built app with forked/updated repository and manually tested splash screen background color with RGB and 'transparent' values.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
