### PR TITLE
CB-13829 Fix tests that were broken since CB-13237

### DIFF
--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -73,29 +73,29 @@ describe('Cordova create and build', function () {
 
     // default
 
-    it('spec.2 should build default (win10) project', function () {
+    it('spec.2a should build default (win10) project', function () {
         shell.exec(buildScriptPath + '', {silent: silent});
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
 
     // --appx
 
-    it('spec.2a should build uap/win10 project', function () {
+    it('spec.2b should build uap/win10 project', function () {
         shell.exec(buildScriptPath + ' --appx=uap', {silent: silent});
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
 
-    it('spec.2b should build 8.1 win project', function () {
+    it('spec.2c should build 8.1 win project', function () {
         shell.exec(buildScriptPath + ' --appx=8.1-win', {silent: silent});
         _expectExist(/.*Windows.*\.appxupload/);
     });
 
-    it('spec.2c should build 8.1 phone project', function () {
+    it('spec.2d should build 8.1 phone project', function () {
         shell.exec(buildScriptPath + ' --appx=8.1-phone', {silent: silent});
         _expectExist(/.*Phone.*\.appxupload/);
     });
 
-    it('spec.2c should build 8.1 win + phone project', function () {
+    it('spec.2e should build 8.1 win + phone project', function () {
         shell.exec(buildScriptPath + ' --appx=8.1', {silent: silent});
         _expectExist(/.*Windows.*\.appxupload/);
         _expectExist(/.*Phone.*\.appxupload/);
@@ -229,6 +229,7 @@ describe('Cordova create and build', function () {
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_x86_Test', 'CordovaApp.Phone_1.0.0.0_x86.appx');
     });
 
+    // this will be move up again when it is fixed for VS 2017
     it('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', {silent: silent});
         _expectExist(/.*bundle\.appxupload$/, 3);

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -79,7 +79,7 @@ describe('Cordova create and build', function () {
 
     // --appx
 
-    it('spec.2a should build win10 project', function () {
+    it('spec.2a should build uap/win10 project', function () {
         shell.exec(buildScriptPath + ' --appx=uap', {silent: silent});
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
@@ -107,18 +107,18 @@ describe('Cordova create and build', function () {
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x64_debug.appx');
     });
 
-    it('spec.3b should build project for particular CPU', function () {
+    it('spec.3b should build project (8.1) for particular CPU', function () {
         shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
         _expectExist(/.*Phone.*x64.*\.appxupload/);
         _expectExist(/.*Windows.*x64.*\.appxupload/);
     });
 
-    it('spec.3c should build project for particular CPU', function () {
+    it('spec.3c should build project (8.1-win) for particular CPU', function () {
         shell.exec(buildScriptPath + ' --appx=8.1-win --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
         _expectExist(/.*Windows.*x64.*\.appxupload/);
     });
 
-    it('spec.3d should build project for particular CPU', function () {
+    it('spec.3d should build project (8.1-phone) for particular CPU', function () {
         shell.exec(buildScriptPath + ' --appx=8.1-phone --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
         _expectExist(/.*Phone.*x64.*\.appxupload/);
     });
@@ -131,7 +131,7 @@ describe('Cordova create and build', function () {
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
 
-    it('spec.4b should build project for CPUs separated by whitespaces', function () {
+    it('spec.4b should build project (8.1) for CPUs separated by whitespaces', function () {
         shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64 x86 arm anycpu\"', {silent: silent}); /* eslint no-useless-escape : 0 */
         _expectExist(/.*Phone.*x86.*\.appxupload/);
         _expectExist(/.*Phone.*x64.*\.appxupload/);
@@ -200,13 +200,13 @@ describe('Cordova create and build', function () {
 
     // --release --bundle
 
-    it('spec.6 should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
+    it('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', {silent: silent});
         _expectExist(/.*bundle\.appxupload$/, 3);
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_Test', 'CordovaApp.Windows10_1.0.0.0_x64_x86_arm.appxbundle');
     });
 
-    it('spec.7 should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
+    it('spec.6b should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --appx=8.1-phone --bundle --archs=\"x64 x86 arm\"', {silent: silent});
         _expectExist(/.*bundle\.appxupload$/, 3);
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_Test', 'CordovaApp.Phone_1.0.0.0_x64_x86_arm.appxbundle');
@@ -214,13 +214,7 @@ describe('Cordova create and build', function () {
 
     // --release (non-bundle)
 
-    it('spec.8 should generate appxupload for Windows 10 project non-bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --win --archs=\"x64 x86 arm\"', {silent: silent});
-        _expectExist(/.*\.appxupload$/, 3);
-
-    });
-
-    it('spec.9a should generate appxupload for Windows 10 project non-bundle release build', function () {
+    it('spec.7 should generate appxupload for Windows 10 project non-bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --archs=\"x64 x86 arm\"', {silent: silent});
         _expectExist(/.*\.appxupload$/, 3);
         // CB-12416 Should build appx in separate dirs for each architecture
@@ -231,7 +225,7 @@ describe('Cordova create and build', function () {
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x86_Test', 'CordovaApp.Windows10_1.0.0.0_x86.appx');
     });
 
-    it('spec.9b for a non-bundle case for Windows Phone 8.1 it should build appx in separate dirs for each architecture', function () {
+    it('spec.8 for a non-bundle case for Windows Phone 8.1 it should build appx in separate dirs for each architecture', function () {
         shell.exec(buildScriptPath + ' --release --appx=8.1-phone --phone --archs=\"x86 arm\"', {silent: silent});
         _expectExist(/.*\.appxupload$/, 2);
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_arm_Test', 'CordovaApp.Phone_1.0.0.0_arm.appx');

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -55,11 +55,24 @@ describe('Cordova create and build', function () {
         expect(fs.existsSync(projectFolder)).toBe(true);
     });
 
-    it('spec.2 should build project', function () {
+    it('spec.2a should build default (win10) project', function () {
         shell.exec(buildScriptPath + '', {silent: silent});
         var packages = shell.ls(appPackagesFolder);
-        expect(packages.filter(function (file) { return file.match(/.*Phone.*\.appx.*/); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(/.*Windows.*\.appx.*/); }).length).toBe(1);
+        var subDir = 'CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test';
+        expect(packages.filter(function (file) { return file.match(subDir); }).length).toBe(1);
+        verifySubDirContainsFile(subDir, 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
+    });
+
+    it('spec.2b should build 8.1 win project', function () {
+        shell.exec(buildScriptPath + ' --appx=8.1-win', {silent: silent});
+        var packages = shell.ls(appPackagesFolder);
+        expect(packages.filter(function (file) { return file.match(/.*Windows.*\.appxupload/); }).length).toBe(1);
+    });
+
+    it('spec.2c should build 8.1 phone project', function () {
+        shell.exec(buildScriptPath + ' --appx=8.1-phone', {silent: silent});
+        var packages = shell.ls(appPackagesFolder);
+        expect(packages.filter(function (file) { return file.match(/.*Phone.*\.appxupload*/); }).length).toBe(1);
     });
 
     it('spec.3 should build project for particular CPU', function () {

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -35,19 +35,24 @@ describe('Cordova create and build', function () {
     var appPackagesFolder = path.join(buildDirectory, projectFolder, 'AppPackages');
     var buildScriptPath = '"' + path.join(buildDirectory, projectFolder, 'cordova', 'build') + '"';
     var silent = true;
+    function verifySubDirContainsFile (subDirName, fileName, count) {
+        count = typeof count !== 'undefined' ? count : 1;
 
-    function verifySubDirContainsFile (subDirName, fileName, count = 1) {
         var subDir = path.join(appPackagesFolder, subDirName);
         var packages = shell.ls(subDir);
         expect(packages.filter(function (file) { return file.match(fileName); }).length).toBe(count);
     }
 
-    function _expectExist (fileNamePattern, count = 1) {
+    function _expectExist (fileNamePattern, count) {
+        count = typeof count !== 'undefined' ? count : 1;
+
         var packages = shell.ls(appPackagesFolder);
         expect(packages.filter(function (file) { return file.match(fileNamePattern); }).length).toBe(count);
     }
 
-    function _expectSubdirAndFileExist (subDirName, fileName, count = 1) {
+    function _expectSubdirAndFileExist (subDirName, fileName, count) {
+        count = typeof count !== 'undefined' ? count : 1;
+
         _expectExist(subDirName);
         verifySubDirContainsFile(subDirName, fileName, count);
     }

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -34,7 +34,8 @@ describe('Cordova create and build', function () {
     var buildDirectory = path.join(__dirname, '../..');
     var appPackagesFolder = path.join(buildDirectory, projectFolder, 'AppPackages');
     var buildScriptPath = '"' + path.join(buildDirectory, projectFolder, 'cordova', 'build') + '"';
-    var silent = true;
+    var silent = false;
+
     function verifySubDirContainsFile (subDirName, fileName, count) {
         count = typeof count !== 'undefined' ? count : 1;
 
@@ -200,7 +201,7 @@ describe('Cordova create and build', function () {
 
     // --release --bundle
 
-    it('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
+    fit('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', {silent: silent});
         _expectExist(/.*bundle\.appxupload$/, 3);
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_Test', 'CordovaApp.Windows10_1.0.0.0_x64_x86_arm.appxbundle');

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -42,6 +42,17 @@ describe('Cordova create and build', function () {
         expect(packages.filter(function (file) { return file.match(fileName); }).length).toBe(1);
     }
 
+    function _expectExist(fileNamePattern) {
+        var packages = shell.ls(appPackagesFolder);
+        expect(packages.filter(function (file) { return file.match(fileNamePattern); }).length).toBe(1);
+    }
+
+    function _expectSubdirAndFileExist(subDirName, fileName) {
+        var packages = shell.ls(appPackagesFolder);
+        _expectExist(subDirName);
+        verifySubDirContainsFile(subDirName, fileName);
+    }
+
     beforeEach(function () {
         shell.exec(path.join('bin', 'create') + ' "' + projectFolder + '" com.test.app 応用', {silent: silent});
     });
@@ -55,28 +66,28 @@ describe('Cordova create and build', function () {
         expect(fs.existsSync(projectFolder)).toBe(true);
     });
 
-    // default build
+    // default
     
-    it('spec.2a should build default (win10) project', function () {
+    it('spec.2 should build default (win10) project', function () {
         shell.exec(buildScriptPath + '', {silent: silent});
-        var packages = shell.ls(appPackagesFolder);
-        var subDir = 'CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test';
-        expect(packages.filter(function (file) { return file.match(subDir); }).length).toBe(1);
-        verifySubDirContainsFile(subDir, 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
 
-    // --appx 8.1
+    // --appx
+
+    it('spec.2a should build win10 project', function () {
+        shell.exec(buildScriptPath + ' --appx=uap', {silent: silent});
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
+    });
 
     it('spec.2b should build 8.1 win project', function () {
         shell.exec(buildScriptPath + ' --appx=8.1-win', {silent: silent});
-        var packages = shell.ls(appPackagesFolder);
-        expect(packages.filter(function (file) { return file.match(/.*Windows.*\.appxupload/); }).length).toBe(1);
+        _expectExist(/.*Windows.*\.appxupload/);
     });
 
     it('spec.2c should build 8.1 phone project', function () {
         shell.exec(buildScriptPath + ' --appx=8.1-phone', {silent: silent});
-        var packages = shell.ls(appPackagesFolder);
-        expect(packages.filter(function (file) { return file.match(/.*Phone.*\.appxupload*/); }).length).toBe(1);
+        _expectExist(/.*Phone.*\.appxupload/);
     });
 
     // --archs

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -90,6 +90,12 @@ describe('Cordova create and build', function () {
         _expectExist(/.*Phone.*\.appxupload/);
     });
 
+    it('spec.2c should build 8.1 win + phone project', function () {
+        shell.exec(buildScriptPath + ' --appx=8.1', {silent: silent});
+        _expectExist(/.*Windows.*\.appxupload/);
+        _expectExist(/.*Phone.*\.appxupload/);
+    });
+
     // --archs
     
     it('spec.3 should build project for particular CPU', function () {

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -34,23 +34,22 @@ describe('Cordova create and build', function () {
     var buildDirectory = path.join(__dirname, '../..');
     var appPackagesFolder = path.join(buildDirectory, projectFolder, 'AppPackages');
     var buildScriptPath = '"' + path.join(buildDirectory, projectFolder, 'cordova', 'build') + '"';
-    var silent = true;
+    var silent = false;
 
-    function verifySubDirContainsFile (subDirName, fileName) {
+    function verifySubDirContainsFile (subDirName, fileName, count = 1) {
         var subDir = path.join(appPackagesFolder, subDirName);
         var packages = shell.ls(subDir);
-        expect(packages.filter(function (file) { return file.match(fileName); }).length).toBe(1);
+        expect(packages.filter(function (file) { return file.match(fileName); }).length).toBe(count);
     }
 
-    function _expectExist(fileNamePattern) {
+    function _expectExist (fileNamePattern, count = 1) {
         var packages = shell.ls(appPackagesFolder);
-        expect(packages.filter(function (file) { return file.match(fileNamePattern); }).length).toBe(1);
+        expect(packages.filter(function (file) { return file.match(fileNamePattern); }).length).toBe(count);
     }
 
-    function _expectSubdirAndFileExist(subDirName, fileName) {
-        var packages = shell.ls(appPackagesFolder);
+    function _expectSubdirAndFileExist (subDirName, fileName, count = 1) {
         _expectExist(subDirName);
-        verifySubDirContainsFile(subDirName, fileName);
+        verifySubDirContainsFile(subDirName, fileName, count);
     }
 
     beforeEach(function () {
@@ -67,7 +66,7 @@ describe('Cordova create and build', function () {
     });
 
     // default
-    
+
     it('spec.2 should build default (win10) project', function () {
         shell.exec(buildScriptPath + '', {silent: silent});
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
@@ -97,30 +96,51 @@ describe('Cordova create and build', function () {
     });
 
     // --archs
-    
-    it('spec.3 should build project for particular CPU', function () {
+
+    it('spec.3a should build project for particular CPU', function () {
         shell.exec(buildScriptPath + ' --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
-        var packages = shell.ls(appPackagesFolder);
-        expect(packages.filter(function (file) { return file.match(/.*Phone.*x64.*\.appx.*/); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(/.*Windows.*x64.*\.appx.*/); }).length).toBe(1);
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x64_debug.appx');
     });
 
-    it('spec.4 should build project for CPUs separated by whitespaces', function () {
+    it('spec.3b should build project for particular CPU', function () {
+        shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
+        _expectExist(/.*Phone.*x64.*\.appxupload/);
+        _expectExist(/.*Windows.*x64.*\.appxupload/);
+    });
+
+    it('spec.3c should build project for particular CPU', function () {
+        shell.exec(buildScriptPath + ' --appx=8.1-win --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
+        _expectExist(/.*Windows.*x64.*\.appxupload/);
+    });
+
+    it('spec.3d should build project for particular CPU', function () {
+        shell.exec(buildScriptPath + ' --appx=8.1-phone --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
+        _expectExist(/.*Phone.*x64.*\.appxupload/);
+    });
+
+    it('spec.4a should build project for CPUs separated by whitespaces', function () {
         shell.exec(buildScriptPath + ' --archs=\"x64 x86 arm anycpu\"', {silent: silent}); /* eslint no-useless-escape : 0 */
-        var packages = shell.ls(appPackagesFolder);
-        expect(packages.filter(function (file) { return file.match(/.*Phone.*x86.*\.appx.*/); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(/.*Phone.*x64.*\.appx.*/); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(/.*Phone.*arm.*\.appx.*/); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(/.*Phone.*AnyCPU.*\.appx.*/i); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(/.*Windows.*x64.*\.appx.*/); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(/.*Windows.*x86.*\.appx.*/); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(/.*Windows.*arm.*\.appx.*/); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(/.*Windows.*anycpu.*\.appx.*/i); }).length).toBe(1);
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x64_debug.appx');
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x86_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x86_debug.appx');
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_arm_debug_Test', 'CordovaApp.Windows10_1.0.0.0_arm_debug.appx');
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
+    });
+
+    it('spec.4b should build project for CPUs separated by whitespaces', function () {
+        shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64 x86 arm anycpu\"', {silent: silent}); /* eslint no-useless-escape : 0 */
+        _expectExist(/.*Phone.*x86.*\.appxupload/);
+        _expectExist(/.*Phone.*x64.*\.appxupload/);
+        _expectExist(/.*Phone.*arm.*\.appxupload/);
+        _expectExist(/.*Phone.*AnyCPU.*\.appxupload/i);
+        _expectExist(/.*Windows.*x64.*\.appxupload/);
+        _expectExist(/.*Windows.*x86.*\.appxupload/);
+        _expectExist(/.*Windows.*arm.*\.appxupload/);
+        _expectExist(/.*Windows.*anycpu.*\.appxupload/i);
     });
 
     // "InProcessServer extension"
 
-    it('spec.5 should build project containing plugin with InProcessServer extension', function (done) {
+    it('spec.5a should build project containing plugin with InProcessServer extension', function (done) {
         var extensionsPluginInfo, api;
 
         extensionsPluginInfo = new PluginInfo(extensionsPlugin);
@@ -137,9 +157,7 @@ describe('Cordova create and build', function () {
         api.addPlugin(extensionsPluginInfo)
             .then(function () {
                 shell.exec(buildScriptPath, {silent: silent});
-                var packages = shell.ls(appPackagesFolder);
-                expect(packages.filter(function (file) { return file.match(/.*Phone.*\.appx.*/); }).length).toBe(1);
-                expect(packages.filter(function (file) { return file.match(/.*Windows.*\.appx.*/); }).length).toBe(1);
+                _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
             })
             .catch(fail)
             .finally(function () {
@@ -148,74 +166,70 @@ describe('Cordova create and build', function () {
             });
     });
 
-    // --release 8.1
+    it('spec.5b should build project (8.1) containing plugin with InProcessServer extension', function (done) {
+        var extensionsPluginInfo, api;
 
-    it('spec.6 should generate appxupload and appxbundle for Windows 8.1 project bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --win --bundle --archs=\"x64 x86 arm\"', {silent: silent});
-        var packages = shell.ls(appPackagesFolder);
-        expect(packages.filter(function (file) { return file.match(/.*bundle\.appxupload$/); }).length > 0).toBeTruthy();
+        extensionsPluginInfo = new PluginInfo(extensionsPlugin);
+        api = new Api();
+        api.root = projectFolder;
+        api.locations.root = projectFolder;
+        api.locations.www = path.join(projectFolder, 'www');
 
-        var bundleDirName = 'CordovaApp.Windows_1.0.0.0_Test';
-        expect(packages.filter(function (file) { return file.match(bundleDirName); }).length).toBe(1);
+        var fail = jasmine.createSpy('fail')
+            .and.callFake(function (err) {
+                console.error(err);
+            });
 
-        verifySubDirContainsFile(bundleDirName, 'CordovaApp.Windows_1.0.0.0_x64_x86_arm.appxbundle');
+        api.addPlugin(extensionsPluginInfo)
+            .then(function () {
+                shell.exec(buildScriptPath + ' --appx=8.1', {silent: silent});
+                _expectExist(/.*Windows.*\.appxupload/);
+                _expectExist(/.*Phone.*\.appxupload/);
+            })
+            .catch(fail)
+            .finally(function () {
+                expect(fail).not.toHaveBeenCalled();
+                done();
+            });
     });
 
-    it('spec.6.1 should generate appxupload for Windows 8.1 project non-bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --win --archs=\"x64 x86 arm\"', {silent: silent});
-        var packages = shell.ls(appPackagesFolder);
-        expect(packages.filter(function (file) { return file.match(/.*\.appxupload$/); }).length).toBe(3);
-    });
+    // --release --bundle
 
-    // --release 10
+    it('spec.6 should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
+        shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', {silent: silent});
+        _expectExist(/.*bundle\.appxupload$/, 3);
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_Test', 'CordovaApp.Windows10_1.0.0.0_x64_x86_arm.appxbundle');
+    });
 
     it('spec.7 should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --win --appx=uap --bundle --archs=\"x64 x86 arm\"', {silent: silent});
-        var packages = shell.ls(appPackagesFolder);
-        expect(packages.filter(function (file) { return file.match(/.*bundle\.appxupload$/); }).length > 0).toBeTruthy();
-
-        var bundleDirName = 'CordovaApp.Windows10_1.0.0.0_Test';
-        expect(packages.filter(function (file) { return file.match(bundleDirName); }).length).toBe(1);
-
-        verifySubDirContainsFile(bundleDirName, 'CordovaApp.Windows10_1.0.0.0_x64_x86_arm.appxbundle');
+        shell.exec(buildScriptPath + ' --release --appx=8.1-phone --bundle --archs=\"x64 x86 arm\"', {silent: silent});
+        _expectExist(/.*bundle\.appxupload$/, 3);
+        _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_Test', 'CordovaApp.Phone_1.0.0.0_x64_x86_arm.appxbundle');
     });
 
-    it('spec.7.1 should generate appxupload for Windows 10 project non-bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --win --appx=uap --archs=\"x64 x86 arm\"', {silent: silent});
-        var packages = shell.ls(appPackagesFolder);
-        expect(packages.filter(function (file) { return file.match(/.*\.appxupload$/); }).length).toBe(3);
+    // --release (non-bundle)
 
+    it('spec.8 should generate appxupload for Windows 10 project non-bundle release build', function () {
+        shell.exec(buildScriptPath + ' --release --win --archs=\"x64 x86 arm\"', {silent: silent});
+        _expectExist(/.*\.appxupload$/, 3);
+
+    });
+
+    it('spec.9a should generate appxupload for Windows 10 project non-bundle release build', function () {
+        shell.exec(buildScriptPath + ' --release --archs=\"x64 x86 arm\"', {silent: silent});
+        _expectExist(/.*\.appxupload$/, 3);
         // CB-12416 Should build appx in separate dirs for each architecture
-        var armSubDir = 'CordovaApp.Windows10_1.0.0.0_arm_Test';
-        var x64SubDir = 'CordovaApp.Windows10_1.0.0.0_x64_Test';
-        var x86SubDir = 'CordovaApp.Windows10_1.0.0.0_x86_Test';
-
         // Should contain a subdirectory for each of the architectures
-        expect(packages.filter(function (file) { return file.match(armSubDir); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(x64SubDir); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(x86SubDir); }).length).toBe(1);
-
         // These subdirectories should contain corresponding appx files
-        verifySubDirContainsFile(armSubDir, 'CordovaApp.Windows10_1.0.0.0_arm.appx');
-        verifySubDirContainsFile(x64SubDir, 'CordovaApp.Windows10_1.0.0.0_x64.appx');
-        verifySubDirContainsFile(x86SubDir, 'CordovaApp.Windows10_1.0.0.0_x86.appx');
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_arm_Test', 'CordovaApp.Windows10_1.0.0.0_arm.appx');
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_Test', 'CordovaApp.Windows10_1.0.0.0_x64.appx');
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x86_Test', 'CordovaApp.Windows10_1.0.0.0_x86.appx');
     });
 
-    // --release 8.1
-
-    it('spec.8 for a non-bundle case for Windows Phone 8.1 it should build appx in separate dirs for each architecture', function () {
-        shell.exec(buildScriptPath + ' --release --phone --archs=\"x86 arm\"', {silent: silent});
-        var packages = shell.ls(appPackagesFolder);
-
-        var armSubDir = 'CordovaApp.Phone_1.0.0.0_arm_Test';
-        var x86SubDir = 'CordovaApp.Phone_1.0.0.0_x86_Test';
-
-        // Should contain a subdirectory for each of the architectures
-        expect(packages.filter(function (file) { return file.match(armSubDir); }).length).toBe(1);
-        expect(packages.filter(function (file) { return file.match(x86SubDir); }).length).toBe(1);
-
-        // These subdirectories should contain corresponding appx files
-        verifySubDirContainsFile(armSubDir, 'CordovaApp.Phone_1.0.0.0_arm.appx');
-        verifySubDirContainsFile(x86SubDir, 'CordovaApp.Phone_1.0.0.0_x86.appx');
+    it('spec.9b for a non-bundle case for Windows Phone 8.1 it should build appx in separate dirs for each architecture', function () {
+        shell.exec(buildScriptPath + ' --release --appx=8.1-phone --phone --archs=\"x86 arm\"', {silent: silent});
+        _expectExist(/.*\.appxupload$/, 2);
+        _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_arm_Test', 'CordovaApp.Phone_1.0.0.0_arm.appx');
+        _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_x86_Test', 'CordovaApp.Phone_1.0.0.0_x86.appx');
     });
 });

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -34,6 +34,7 @@ describe('Cordova create and build', function () {
     var buildDirectory = path.join(__dirname, '../..');
     var appPackagesFolder = path.join(buildDirectory, projectFolder, 'AppPackages');
     var buildScriptPath = '"' + path.join(buildDirectory, projectFolder, 'cordova', 'build') + '"';
+    var silent = true;
 
     function verifySubDirContainsFile (subDirName, fileName) {
         var subDir = path.join(appPackagesFolder, subDirName);
@@ -42,7 +43,7 @@ describe('Cordova create and build', function () {
     }
 
     beforeEach(function () {
-        shell.exec(path.join('bin', 'create') + ' "' + projectFolder + '" com.test.app 応用', {silent: true});
+        shell.exec(path.join('bin', 'create') + ' "' + projectFolder + '" com.test.app 応用', {silent: silent});
     });
 
     afterEach(function () {
@@ -55,21 +56,21 @@ describe('Cordova create and build', function () {
     });
 
     it('spec.2 should build project', function () {
-        shell.exec(buildScriptPath, {silent: true});
+        shell.exec(buildScriptPath + '', {silent: silent});
         var packages = shell.ls(appPackagesFolder);
         expect(packages.filter(function (file) { return file.match(/.*Phone.*\.appx.*/); }).length).toBe(1);
         expect(packages.filter(function (file) { return file.match(/.*Windows.*\.appx.*/); }).length).toBe(1);
     });
 
     it('spec.3 should build project for particular CPU', function () {
-        shell.exec(buildScriptPath + ' --archs=\"x64\"', {silent: true}); /* eslint no-useless-escape : 0 */
+        shell.exec(buildScriptPath + ' --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
         var packages = shell.ls(appPackagesFolder);
         expect(packages.filter(function (file) { return file.match(/.*Phone.*x64.*\.appx.*/); }).length).toBe(1);
         expect(packages.filter(function (file) { return file.match(/.*Windows.*x64.*\.appx.*/); }).length).toBe(1);
     });
 
     it('spec.4 should build project for CPUs separated by whitespaces', function () {
-        shell.exec(buildScriptPath + ' --archs=\"x64 x86 arm anycpu\"', {silent: true}); /* eslint no-useless-escape : 0 */
+        shell.exec(buildScriptPath + ' --archs=\"x64 x86 arm anycpu\"', {silent: silent}); /* eslint no-useless-escape : 0 */
         var packages = shell.ls(appPackagesFolder);
         expect(packages.filter(function (file) { return file.match(/.*Phone.*x86.*\.appx.*/); }).length).toBe(1);
         expect(packages.filter(function (file) { return file.match(/.*Phone.*x64.*\.appx.*/); }).length).toBe(1);
@@ -97,7 +98,7 @@ describe('Cordova create and build', function () {
 
         api.addPlugin(extensionsPluginInfo)
             .then(function () {
-                shell.exec(buildScriptPath, {silent: true});
+                shell.exec(buildScriptPath, {silent: silent});
                 var packages = shell.ls(appPackagesFolder);
                 expect(packages.filter(function (file) { return file.match(/.*Phone.*\.appx.*/); }).length).toBe(1);
                 expect(packages.filter(function (file) { return file.match(/.*Windows.*\.appx.*/); }).length).toBe(1);
@@ -110,7 +111,7 @@ describe('Cordova create and build', function () {
     });
 
     it('spec.6 should generate appxupload and appxbundle for Windows 8.1 project bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --win --bundle --archs=\"x64 x86 arm\"', {silent: true});
+        shell.exec(buildScriptPath + ' --release --win --bundle --archs=\"x64 x86 arm\"', {silent: silent});
         var packages = shell.ls(appPackagesFolder);
         expect(packages.filter(function (file) { return file.match(/.*bundle\.appxupload$/); }).length > 0).toBeTruthy();
 
@@ -121,13 +122,13 @@ describe('Cordova create and build', function () {
     });
 
     it('spec.6.1 should generate appxupload for Windows 8.1 project non-bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --win --archs=\"x64 x86 arm\"', {silent: true});
+        shell.exec(buildScriptPath + ' --release --win --archs=\"x64 x86 arm\"', {silent: silent});
         var packages = shell.ls(appPackagesFolder);
         expect(packages.filter(function (file) { return file.match(/.*\.appxupload$/); }).length).toBe(3);
     });
 
     it('spec.7 should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --win --appx=uap --bundle --archs=\"x64 x86 arm\"', {silent: true});
+        shell.exec(buildScriptPath + ' --release --win --appx=uap --bundle --archs=\"x64 x86 arm\"', {silent: silent});
         var packages = shell.ls(appPackagesFolder);
         expect(packages.filter(function (file) { return file.match(/.*bundle\.appxupload$/); }).length > 0).toBeTruthy();
 
@@ -138,7 +139,7 @@ describe('Cordova create and build', function () {
     });
 
     it('spec.7.1 should generate appxupload for Windows 10 project non-bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --win --appx=uap --archs=\"x64 x86 arm\"', {silent: true});
+        shell.exec(buildScriptPath + ' --release --win --appx=uap --archs=\"x64 x86 arm\"', {silent: silent});
         var packages = shell.ls(appPackagesFolder);
         expect(packages.filter(function (file) { return file.match(/.*\.appxupload$/); }).length).toBe(3);
 
@@ -159,7 +160,7 @@ describe('Cordova create and build', function () {
     });
 
     it('spec.8 for a non-bundle case for Windows Phone 8.1 it should build appx in separate dirs for each architecture', function () {
-        shell.exec(buildScriptPath + ' --release --phone --archs=\"x86 arm\"', {silent: true});
+        shell.exec(buildScriptPath + ' --release --phone --archs=\"x86 arm\"', {silent: silent});
         var packages = shell.ls(appPackagesFolder);
 
         var armSubDir = 'CordovaApp.Phone_1.0.0.0_arm_Test';

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -34,7 +34,7 @@ describe('Cordova create and build', function () {
     var buildDirectory = path.join(__dirname, '../..');
     var appPackagesFolder = path.join(buildDirectory, projectFolder, 'AppPackages');
     var buildScriptPath = '"' + path.join(buildDirectory, projectFolder, 'cordova', 'build') + '"';
-    var silent = false;
+    var silent = true;
 
     function verifySubDirContainsFile (subDirName, fileName, count = 1) {
         var subDir = path.join(appPackagesFolder, subDirName);

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -55,6 +55,8 @@ describe('Cordova create and build', function () {
         expect(fs.existsSync(projectFolder)).toBe(true);
     });
 
+    // default build
+    
     it('spec.2a should build default (win10) project', function () {
         shell.exec(buildScriptPath + '', {silent: silent});
         var packages = shell.ls(appPackagesFolder);
@@ -62,6 +64,8 @@ describe('Cordova create and build', function () {
         expect(packages.filter(function (file) { return file.match(subDir); }).length).toBe(1);
         verifySubDirContainsFile(subDir, 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
+
+    // --appx 8.1
 
     it('spec.2b should build 8.1 win project', function () {
         shell.exec(buildScriptPath + ' --appx=8.1-win', {silent: silent});
@@ -75,6 +79,8 @@ describe('Cordova create and build', function () {
         expect(packages.filter(function (file) { return file.match(/.*Phone.*\.appxupload*/); }).length).toBe(1);
     });
 
+    // --archs
+    
     it('spec.3 should build project for particular CPU', function () {
         shell.exec(buildScriptPath + ' --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
         var packages = shell.ls(appPackagesFolder);
@@ -94,6 +100,8 @@ describe('Cordova create and build', function () {
         expect(packages.filter(function (file) { return file.match(/.*Windows.*arm.*\.appx.*/); }).length).toBe(1);
         expect(packages.filter(function (file) { return file.match(/.*Windows.*anycpu.*\.appx.*/i); }).length).toBe(1);
     });
+
+    // "InProcessServer extension"
 
     it('spec.5 should build project containing plugin with InProcessServer extension', function (done) {
         var extensionsPluginInfo, api;
@@ -123,6 +131,8 @@ describe('Cordova create and build', function () {
             });
     });
 
+    // --release 8.1
+
     it('spec.6 should generate appxupload and appxbundle for Windows 8.1 project bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --win --bundle --archs=\"x64 x86 arm\"', {silent: silent});
         var packages = shell.ls(appPackagesFolder);
@@ -139,6 +149,8 @@ describe('Cordova create and build', function () {
         var packages = shell.ls(appPackagesFolder);
         expect(packages.filter(function (file) { return file.match(/.*\.appxupload$/); }).length).toBe(3);
     });
+
+    // --release 10
 
     it('spec.7 should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --win --appx=uap --bundle --archs=\"x64 x86 arm\"', {silent: silent});
@@ -171,6 +183,8 @@ describe('Cordova create and build', function () {
         verifySubDirContainsFile(x64SubDir, 'CordovaApp.Windows10_1.0.0.0_x64.appx');
         verifySubDirContainsFile(x86SubDir, 'CordovaApp.Windows10_1.0.0.0_x86.appx');
     });
+
+    // --release 8.1
 
     it('spec.8 for a non-bundle case for Windows Phone 8.1 it should build appx in separate dirs for each architecture', function () {
         shell.exec(buildScriptPath + ' --release --phone --archs=\"x86 arm\"', {silent: silent});

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -201,11 +201,7 @@ describe('Cordova create and build', function () {
 
     // --release --bundle
 
-    fit('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', {silent: silent});
-        _expectExist(/.*bundle\.appxupload$/, 3);
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_Test', 'CordovaApp.Windows10_1.0.0.0_x64_x86_arm.appxbundle');
-    });
+    // here be 6a
 
     it('spec.6b should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --appx=8.1-phone --bundle --archs=\"x64 x86 arm\"', {silent: silent});
@@ -231,5 +227,11 @@ describe('Cordova create and build', function () {
         _expectExist(/.*\.appxupload$/, 2);
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_arm_Test', 'CordovaApp.Phone_1.0.0.0_arm.appx');
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_x86_Test', 'CordovaApp.Phone_1.0.0.0_x86.appx');
+    });
+
+    it('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
+        shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', {silent: silent});
+        _expectExist(/.*bundle\.appxupload$/, 3);
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_Test', 'CordovaApp.Windows10_1.0.0.0_x64_x86_arm.appxbundle');
     });
 });

--- a/template/cordova/lib/MSBuildTools.js
+++ b/template/cordova/lib/MSBuildTools.js
@@ -34,6 +34,7 @@ MSBuildTools.prototype.buildProject = function (projFile, buildType, buildarch, 
     events.emit('log', 'Building project: ' + projFile);
     events.emit('log', '\tConfiguration : ' + buildType);
     events.emit('log', '\tPlatform      : ' + buildarch);
+    events.emit('log', '\tBuildflags    : ' + buildFlags);
 
     var checkWinSDK = function (target_platform) {
         return require('./check_reqs').isWinSDKPresent(target_platform);

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -81,6 +81,8 @@ module.exports.getBuildTargets = function (isWinSwitch, isPhoneSwitch, projOverr
     // apply build target override if one was specified
     if (projOverride) {
         switch (projOverride.toLowerCase()) {
+        case '8.1':
+            return [projFiles.win, projFiles.phone];
         case '8.1-phone':
             return [projFiles.phone];
         case '8.1-win':

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -76,7 +76,8 @@ module.exports.run = function run (buildOptions) {
 };
 
 // returns list of projects to be built based on config.xml and additional parameters (-appx)
-function getBuildTargets (isWinSwitch, isPhoneSwitch, projOverride, buildConfig = null) {
+function getBuildTargets (isWinSwitch, isPhoneSwitch, projOverride, buildConfig) {
+    buildConfig = typeof buildConfig  !== 'undefined' ? buildConfig : null;
 
     var configXML = new ConfigParser(path.join(ROOT, 'config.xml'));
     var targets = [];

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -76,24 +76,8 @@ module.exports.run = function run (buildOptions) {
 };
 
 // returns list of projects to be built based on config.xml and additional parameters (-appx)
-module.exports.getBuildTargets = function (isWinSwitch, isPhoneSwitch, projOverride) {
+function getBuildTargets (isWinSwitch, isPhoneSwitch, projOverride, buildConfig = null) {
 
-    // apply build target override if one was specified
-    if (projOverride) {
-        switch (projOverride.toLowerCase()) {
-        case '8.1':
-            return [projFiles.win, projFiles.phone];
-        case '8.1-phone':
-            return [projFiles.phone];
-        case '8.1-win':
-            return [projFiles.win];
-        case 'uap':
-            return [projFiles.win10];
-        default:
-            events.emit('warn', 'Ignoring unrecognized --appx parameter passed to build: "' + projOverride + '"');
-            break;
-        }
-    }
 
     var configXML = new ConfigParser(path.join(ROOT, 'config.xml'));
     var targets = [];
@@ -139,8 +123,50 @@ module.exports.getBuildTargets = function (isWinSwitch, isPhoneSwitch, projOverr
         }
     }
 
+    // apply build target override if one was specified
+    if (projOverride) {
+        switch (projOverride.toLowerCase()) {
+        case '8.1':
+            targets = [projFiles.win, projFiles.phone];
+            break;
+        case '8.1-phone':
+            targets = [projFiles.phone];
+            break;
+        case '8.1-win':
+            targets = [projFiles.win];
+            break;
+        case 'uap':
+            targets = [projFiles.win10];
+            break;
+        default:
+            events.emit('warn', 'Ignoring unrecognized --appx parameter passed to build: "' + projOverride + '"');
+            break;
+        }
+    }
+
+    if(buildConfig !== null) {
+        // As part of reworking how build and package determine the winning project, set the 'target type' project
+        // as part of build configuration.  This will be used for determining the binary to 'run' after build is done.
+        if (targets.length > 0) {
+            switch (targets[0]) {
+            case projFiles.phone:
+                buildConfig.targetProject = 'phone';
+                break;
+            case projFiles.win10:
+                buildConfig.targetProject = 'windows10';
+                break;
+            case projFiles.win:
+                /* falls through */
+            default:
+                buildConfig.targetProject = 'windows';
+                break;
+            }
+        }
+    }
+
     return targets;
 };
+module.exports.getBuildTargets = getBuildTargets;
 
 /**
  * Parses and validates buildOptions object and platform-specific CLI arguments,
@@ -278,7 +304,7 @@ function parseBuildConfig (buildConfigPath, buildType) {
 function updateManifestWithPublisher (allMsBuildVersions, config) {
     if (!config.publisherId) return;
 
-    var selectedBuildTargets = getBuildTargets(config);
+    var selectedBuildTargets = getBuildTargets(config.win, config.phone, config.projVerOverride, config);
     var msbuild = getLatestMSBuild(allMsBuildVersions);
     var myBuildTargets = filterSupportedTargets(selectedBuildTargets, msbuild);
     var manifestFiles = myBuildTargets.map(function (proj) {
@@ -293,7 +319,7 @@ function updateManifestWithPublisher (allMsBuildVersions, config) {
 
 function buildTargets (allMsBuildVersions, config) {
     // filter targets to make sure they are supported on this development machine
-    var selectedBuildTargets = getBuildTargets(config);
+    var selectedBuildTargets = getBuildTargets(config.win, config.phone, config.projVerOverride, config);
     var msbuild = getLatestMSBuild(allMsBuildVersions);
     if (!msbuild) {
         return Q.reject(new CordovaError('No valid MSBuild was detected for the selected target.'));
@@ -409,92 +435,6 @@ function clearIntermediatesAndGetPackage (bundleTerms, config, hasAnyCpu) {
     });
 
     return pckage.getPackageFileInfo(finalFile);
-}
-
-// Can update buildConfig in the following ways:
-//  * Sets targetProject property, the project to launch when complete
-function getBuildTargets (buildConfig) {
-    var configXML = new ConfigParser(path.join(ROOT, 'config.xml'));
-    var targets = [];
-    var noSwitches = !(buildConfig.phone || buildConfig.win);
-
-    // Windows
-    if (buildConfig.win || noSwitches) { // if --win or no arg
-        var windowsTargetVersion = configXML.getWindowsTargetVersion();
-        switch (windowsTargetVersion) {
-        case '8':
-        case '8.0':
-            throw new CordovaError('windows8 platform is deprecated. To use windows-target-version=8.0 you must downgrade to cordova-windows@4.');
-        case '8.1':
-            targets.push(projFiles.win);
-            break;
-        case '10.0':
-        case 'UAP':
-            targets.push(projFiles.win10);
-            break;
-        default:
-            throw new Error('Unsupported windows-target-version value: ' + windowsTargetVersion);
-        }
-    }
-
-    // Windows Phone
-    if (buildConfig.phone || noSwitches) { // if --phone or no arg
-        var windowsPhoneTargetVersion = configXML.getWindowsPhoneTargetVersion();
-        switch (windowsPhoneTargetVersion) {
-        case '8.1':
-            targets.push(projFiles.phone);
-            break;
-        case '10.0':
-        case 'UAP':
-            if (!buildConfig.win && !noSwitches) {
-                // Already built due to --win or no switches
-                // and since the same thing can be run on Phone as Windows,
-                // we can skip this one.
-                targets.push(projFiles.win10);
-            }
-            break;
-        default:
-            throw new Error('Unsupported windows-phone-target-version value: ' + windowsPhoneTargetVersion);
-        }
-    }
-
-    // apply build target override if one was specified
-    if (buildConfig.projVerOverride) {
-        switch (buildConfig.projVerOverride) {
-        case '8.1-phone':
-            targets = [projFiles.phone];
-            break;
-        case '8.1-win':
-            targets = [projFiles.win];
-            break;
-        case 'uap':
-            targets = [projFiles.win10];
-            break;
-        default:
-            events.emit('warn', 'Ignoring unrecognized --appx parameter passed to build: "' + buildConfig.projVerOverride + '"');
-            break;
-        }
-    }
-
-    // As part of reworking how build and package determine the winning project, set the 'target type' project
-    // as part of build configuration.  This will be used for determining the binary to 'run' after build is done.
-    if (targets.length > 0) {
-        switch (targets[0]) {
-        case projFiles.phone:
-            buildConfig.targetProject = 'phone';
-            break;
-        case projFiles.win10:
-            buildConfig.targetProject = 'windows10';
-            break;
-        case projFiles.win:
-            /* falls through */
-        default:
-            buildConfig.targetProject = 'windows';
-            break;
-        }
-    }
-
-    return targets;
 }
 
 function getLatestMSBuild (allMsBuildVersions) {

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -78,7 +78,6 @@ module.exports.run = function run (buildOptions) {
 // returns list of projects to be built based on config.xml and additional parameters (-appx)
 function getBuildTargets (isWinSwitch, isPhoneSwitch, projOverride, buildConfig = null) {
 
-
     var configXML = new ConfigParser(path.join(ROOT, 'config.xml'));
     var targets = [];
     var noSwitches = !(isPhoneSwitch || isWinSwitch);
@@ -144,7 +143,7 @@ function getBuildTargets (isWinSwitch, isPhoneSwitch, projOverride, buildConfig 
         }
     }
 
-    if(buildConfig !== null) {
+    if (buildConfig !== null) {
         // As part of reworking how build and package determine the winning project, set the 'target type' project
         // as part of build configuration.  This will be used for determining the binary to 'run' after build is done.
         if (targets.length > 0) {
@@ -165,7 +164,7 @@ function getBuildTargets (isWinSwitch, isPhoneSwitch, projOverride, buildConfig 
     }
 
     return targets;
-};
+}
 module.exports.getBuildTargets = getBuildTargets;
 
 /**

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -77,7 +77,7 @@ module.exports.run = function run (buildOptions) {
 
 // returns list of projects to be built based on config.xml and additional parameters (-appx)
 function getBuildTargets (isWinSwitch, isPhoneSwitch, projOverride, buildConfig) {
-    buildConfig = typeof buildConfig  !== 'undefined' ? buildConfig : null;
+    buildConfig = typeof buildConfig !== 'undefined' ? buildConfig : null;
 
     var configXML = new ConfigParser(path.join(ROOT, 'config.xml'));
     var targets = [];

--- a/template/cordova/prebuild.js
+++ b/template/cordova/prebuild.js
@@ -23,7 +23,7 @@
 /* eslint no-useless-escape : 0 */
 
 module.exports = function patch (platform) {
-    console.log('Patching ' + platform + ' in prebuild event...');
+    console.log('Prebuild: Patching platform `' + platform + '`');
 
     var shell = require('shelljs');
     var path = require('path');
@@ -75,7 +75,7 @@ module.exports = function patch (platform) {
         var subst = '$1<script type="text/javascript" src="' + basejsSrc + '"></script>\n$1$2';
 
         shell.sed('-i', appendBaseJsRe, subst, startPageFilePath);
-        console.log('Injected base.js reference to the ' + startPage);
+        console.log('Injected `base.js` reference to `' + startPage + '`');
 
         // 4. Remove all 'wrong' base.js references, which might left from another project type build:
         for (var plat in basejsSrcMap) {


### PR DESCRIPTION
### Platforms affected
Windows 10, Visual Studio 2015 and 2017

### What does this PR do?
This PR fixes the e2e tests that were broken since https://issues.apache.org/jira/browse/CB-13237 was merged which was not caught because of broken CI.

For that I rewrote all of them from "default 8.1" to "default 10" by fixing the `expect`s, extracting the comparison stuff in its own function along the way. I think I replicated all test cases that were there before.

### What testing has been done on this change?
Local runs of e2e test suite + CI.

Note: The remaining 1 failing test with Visual Studio 2017 is from another, unrelated change (that was also not caught because of broken CI). I changed the order of tests so it is the last one being executed, so all the others are passing. This one will be tackled in https://issues.apache.org/jira/browse/CB-13834

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
