### PR TITLE
CB-13817 Add new alias `uwp` for `--appx` param including tests

### DIFF
--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -80,22 +80,27 @@ describe('Cordova create and build', function () {
 
     // --appx
 
-    it('spec.2b should build uap/win10 project', function () {
+    it('spec.2b should build uap (win10) project', function () {
         shell.exec(buildScriptPath + ' --appx=uap', {silent: silent});
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
 
-    it('spec.2c should build 8.1 win project', function () {
+    it('spec.2cshould build uwp (win10) project', function () {
+        shell.exec(buildScriptPath + ' --appx=uwp', {silent: silent});
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
+    });
+
+    it('spec.2d should build 8.1 win project', function () {
         shell.exec(buildScriptPath + ' --appx=8.1-win', {silent: silent});
         _expectExist(/.*Windows.*\.appxupload/);
     });
 
-    it('spec.2d should build 8.1 phone project', function () {
+    it('spec.2e should build 8.1 phone project', function () {
         shell.exec(buildScriptPath + ' --appx=8.1-phone', {silent: silent});
         _expectExist(/.*Phone.*\.appxupload/);
     });
 
-    it('spec.2e should build 8.1 win + phone project', function () {
+    it('spec.2f should build 8.1 win + phone project', function () {
         shell.exec(buildScriptPath + ' --appx=8.1', {silent: silent});
         _expectExist(/.*Windows.*\.appxupload/);
         _expectExist(/.*Phone.*\.appxupload/);
@@ -203,7 +208,7 @@ describe('Cordova create and build', function () {
 
     // here be 6a
 
-    it('spec.6b should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
+    it('spec.6b should generate appxupload and appxbundle for Windows Phone 8.1 project bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --appx=8.1-phone --bundle --archs=\"x64 x86 arm\"', {silent: silent});
         _expectExist(/.*bundle\.appxupload$/, 3);
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_Test', 'CordovaApp.Phone_1.0.0.0_x64_x86_arm.appxbundle');
@@ -229,7 +234,7 @@ describe('Cordova create and build', function () {
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_x86_Test', 'CordovaApp.Phone_1.0.0.0_x86.appx');
     });
 
-    // this will be move up again when it is fixed for VS 2017
+    // this will be move up again when it is fixed for VS 2017 on AppVeyor
     it('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', {silent: silent});
         _expectExist(/.*bundle\.appxupload$/, 3);

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -85,7 +85,7 @@ describe('Cordova create and build', function () {
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
 
-    it('spec.2cshould build uwp (win10) project', function () {
+    it('spec.2c should build uwp (win10) project', function () {
         shell.exec(buildScriptPath + ' --appx=uwp', {silent: silent});
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });

--- a/spec/unit/build.spec.js
+++ b/spec/unit/build.spec.js
@@ -337,7 +337,7 @@ describe('run method', function () {
             });
     });
 
-    it('spec.13 should be able to override target via --appx parameter', function (done) {
+    it('spec.13a should be able to override target via --appx parameter', function (done) {
         var buildSpy = jasmine.createSpy().and.callFake(function (solutionFile, buildType, buildArch) {
             // check that we build Windows 10 and not Windows 8.1
             expect(solutionFile.toLowerCase()).toMatch('cordovaapp.windows10.jsproj');
@@ -348,6 +348,23 @@ describe('run method', function () {
         createConfigParserMock('8.1', '8.1');
         // explicitly specify Windows 10 as target
         build.run({argv: ['--appx=uap']})
+            .finally(function () {
+                expect(buildSpy).toHaveBeenCalled();
+                done();
+            });
+    });
+
+    it('spec.13b should be able to override target via --appx parameter', function (done) {
+        var buildSpy = jasmine.createSpy().and.callFake(function (solutionFile, buildType, buildArch) {
+            // check that we build Windows 10 and not Windows 8.1
+            expect(solutionFile.toLowerCase()).toMatch('cordovaapp.windows10.jsproj');
+        });
+
+        createFindAllAvailableVersionsMock([{ version: '14.0', buildProject: buildSpy, path: testPath }]);
+        // provision config to target Windows 8.1
+        createConfigParserMock('8.1', '8.1');
+        // explicitly specify Windows 10 as target
+        build.run({argv: ['--appx=uwp']})
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
                 done();
@@ -379,7 +396,7 @@ describe('run method', function () {
             });
     });
 
-    it('spec.15 should choose latest version if there are multiple versions available with minor version difference', function (done) {
+    it('spec.15a should choose latest version if there are multiple versions available with minor version difference', function (done) {
         var fail = jasmine.createSpy('fail');
         var buildTools14 = { version: '14.0', buildProject: jasmine.createSpy('buildTools14'), path: testPath };
         var buildTools15 = { version: '15.0', buildProject: jasmine.createSpy('buildTools15'), path: testPath };
@@ -388,6 +405,23 @@ describe('run method', function () {
         createFindAllAvailableVersionsMock([buildTools14, buildTools15, buildTools151]);
         // explicitly specify Windows 10 as target
         build.run({argv: ['--appx=uap']})
+            .fail(fail)
+            .finally(function () {
+                expect(fail).not.toHaveBeenCalled();
+                expect(buildTools151.buildProject).toHaveBeenCalled();
+                done();
+            });
+    });
+
+    it('spec.15b should choose latest version if there are multiple versions available with minor version difference', function (done) {
+        var fail = jasmine.createSpy('fail');
+        var buildTools14 = { version: '14.0', buildProject: jasmine.createSpy('buildTools14'), path: testPath };
+        var buildTools15 = { version: '15.0', buildProject: jasmine.createSpy('buildTools15'), path: testPath };
+        var buildTools151 = { version: '15.1', buildProject: jasmine.createSpy('buildTools151'), path: testPath };
+
+        createFindAllAvailableVersionsMock([buildTools14, buildTools15, buildTools151]);
+        // explicitly specify Windows 10 as target
+        build.run({argv: ['--appx=uwp']})
             .fail(fail)
             .finally(function () {
                 expect(fail).not.toHaveBeenCalled();

--- a/template/cordova/build
+++ b/template/cordova/build
@@ -41,7 +41,7 @@ if(['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) >= 
     console.log('                                  architectures (`anycpu`, `arm`, `x86`, `x64`).');
     console.log('                                  Separate multiple choices with spaces and if');
     console.log('                                  passing multiple choices, enclose with " ".');
-    console.log('    --appx=<8.1-win|8.1-phone|uap>');
+    console.log('    --appx=<8.1-win|8.1-phone|uap|uwp>');
     console.log('                                : Overrides windows-target-version to build');
     console.log('                                  Windows 8.1, Windows Phone 8.1, or');
     console.log('                                  Windows 10 Universal.');

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -95,6 +95,7 @@ function getBuildTargets (isWinSwitch, isPhoneSwitch, projOverride, buildConfig)
             break;
         case '10.0':
         case 'uap':
+        case 'uwp':
             targets.push(projFiles.win10);
             break;
         default:
@@ -111,6 +112,7 @@ function getBuildTargets (isWinSwitch, isPhoneSwitch, projOverride, buildConfig)
             break;
         case '10.0':
         case 'uap':
+        case 'uwp':
             if (targets.indexOf(projFiles.win10) < 0) {
                 // Already built due to --win or no switches
                 // and since the same thing can be run on Phone as Windows,
@@ -136,6 +138,7 @@ function getBuildTargets (isWinSwitch, isPhoneSwitch, projOverride, buildConfig)
             targets = [projFiles.win];
             break;
         case 'uap':
+        case 'uwp':
             targets = [projFiles.win10];
             break;
         default:

--- a/template/cordova/run
+++ b/template/cordova/run
@@ -41,7 +41,7 @@ if (['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(args[2]) > -1) {
     console.log('                    architectures are used.');
     console.log('    --phone, --win');
     console.log('                  : Specifies project type to deploy');
-    console.log('    --appx=<8.1-win|8.1-phone|uap>');
+    console.log('    --appx=<8.1-win|8.1-phone|uap|uwp>');
     console.log('                  : Overrides windows-target-version to build Windows 8.1, ');
     console.log('                              Windows Phone 8.1, or Windows 10.');
     console.log('    --win10tools  : Uses Windows 10 deployment tools (used for a Windows 8.1 app when');


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-13817

### What does this PR do?

Adds `uwp` as an alias for `uap` to the `--appx` param so one can also use it to trigger a Win10 build.

### What testing has been done on this change?

Locally + CI.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.