### PR TITLE
CB-13870 change default from UAP to 10.0 

### DIFF
--- a/template/cordova/lib/ConfigParser.js
+++ b/template/cordova/lib/ConfigParser.js
@@ -71,7 +71,7 @@ WindowsConfigParser.prototype.getMatchingPreferences = function (regexp) {
 WindowsConfigParser.prototype.getWindowsTargetVersion = function () {
     var preference = this.getPreference('windows-target-version');
 
-    if (!preference) { preference = 'UAP'; } // default is UAP
+    if (!preference) { preference = '10.0'; }
 
     return preference;
 };


### PR DESCRIPTION
### What does this PR do?

... which means the same but works for check_reqs as well.

This is an "update" to https://github.com/apache/cordova-windows/pull/241

### What testing has been done on this change?

Manual installation as platform and ran `cordova requirements` successfully:

```
C:\Projects
λ cd "Cordova Projects\

C:\Projects\Cordova Projects
λ cordova create windowsMaster2
Creating a new cordova project.

C:\Projects\Cordova Projects
λ cd windowsMaster2

C:\Projects\Cordova Projects\windowsMaster2  (helloworld@1.0.0)
λ cordova platform add https://github.com/apache/cordova-windows#master
Using cordova-fetch for https://github.com/apache/cordova-windows#master
Warning: using prerelease platform windows@5.1.0-dev.
Use 'cordova platform add windows@latest' to add the latest published version instead.
Adding windows project...
Creating Cordova Windows Project:
        Path: platforms\windows
        Namespace: io.cordova.hellocordova
        Name: HelloCordova
Windows project created with cordova-windows@5.1.0-dev
Discovered plugin "cordova-plugin-whitelist" in config.xml. Adding it to the project
Installing "cordova-plugin-whitelist" for windows
Adding cordova-plugin-whitelist to package.json
Saved plugin info for "cordova-plugin-whitelist" to config.xml
--save flag or autosave detected
Saving windows@https://github.com/apache/cordova-windows#master into config.xml file ...

C:\Projects\Cordova Projects\windowsMaster2  (helloworld@1.0.0)
λ cordova requirements

Requirements check results for windows:
Windows OS: not installed
Error: Cannot read property 'os' of undefined
(node:11008) UnhandledPromiseRejectionWarning: CordovaError: Some of requirements check failed
    at C:\nvm\v9.4.0\node_modules\cordova\src\cli.js:414:27
    at _fulfilled (C:\nvm\v9.4.0\node_modules\cordova\node_modules\cordova-lib\node_modules\q\q.js:787:54)
    at self.promiseDispatch.done (C:\nvm\v9.4.0\node_modules\cordova\node_modules\cordova-lib\node_modules\q\q.js:816:30)
    at Promise.promise.promiseDispatch (C:\nvm\v9.4.0\node_modules\cordova\node_modules\cordova-lib\node_modules\q\q.js:749:13)
    at C:\nvm\v9.4.0\node_modules\cordova\node_modules\cordova-lib\node_modules\q\q.js:557:44
    at flush (C:\nvm\v9.4.0\node_modules\cordova\node_modules\cordova-lib\node_modules\q\q.js:108:17)
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:11008) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:11008) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

C:\Projects\Cordova Projects\windowsMaster2  (helloworld@1.0.0)
λ cordova platform rm windows
Removing platform windows from config.xml file...
Removing windows from cordova.platforms array in package.json

C:\Projects\Cordova Projects\windowsMaster2  (helloworld@1.0.0)
λ cordova platform add https://github.com/apache/cordova-windows#janpio-CB-13870_2
Using cordova-fetch for https://github.com/apache/cordova-windows#janpio-CB-13870_2
Warning: using prerelease platform windows@5.1.0-dev.
Use 'cordova platform add windows@latest' to add the latest published version instead.
Adding windows project...
Creating Cordova Windows Project:
        Path: platforms\windows
        Namespace: io.cordova.hellocordova
        Name: HelloCordova
Windows project created with cordova-windows@5.1.0-dev
Installing "cordova-plugin-whitelist" for windows
--save flag or autosave detected
Saving windows@https://github.com/apache/cordova-windows#janpio-CB-13870_2 into config.xml file ...

C:\Projects\Cordova Projects\windowsMaster2  (helloworld@1.0.0)
λ cordova requirements

Requirements check results for windows:
Windows OS: installed Windows 10
MSBuild Tools: installed 15.5
Visual Studio: installed (user-specified)
Windows SDK: installed 10.0
Windows Phone SDK: installed 10.0
```
(current `master` first, show the problem, then this branch, show that it works)

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
