### PR TITLE
CB-13875 add `prepare` script that can be called in e2e tests

### DIFF
--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -34,6 +34,8 @@ describe('Cordova create and build', function () {
     var buildDirectory = path.join(__dirname, '../..');
     var appPackagesFolder = path.join(buildDirectory, projectFolder, 'AppPackages');
     var buildScriptPath = '"' + path.join(buildDirectory, projectFolder, 'cordova', 'build') + '"';
+    var prepareScriptPath = '"' + path.join(buildDirectory, projectFolder, 'cordova', 'prepare') + '"';
+
     var silent = false;
 
     function verifySubDirContainsFile (subDirName, fileName, count) {
@@ -60,6 +62,7 @@ describe('Cordova create and build', function () {
 
     beforeEach(function () {
         shell.exec(path.join('bin', 'create') + ' "' + projectFolder + '" com.test.app 応用', {silent: silent});
+        shell.exec(prepareScriptPath + '', {silent: silent});
     });
 
     afterEach(function () {

--- a/template/config.xml
+++ b/template/config.xml
@@ -21,18 +21,4 @@
 -->
 <widget id="io.cordova.hellocordova" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
 	<name>HelloCordova</name>
-    <description>
-        A sample Apache Cordova application that responds to the deviceready event.
-    </description>
-    <author email="dev@cordova.apache.org" href="http://cordova.io">
-        Apache Cordova Team
-    </author>
-    <content src="index.html" />
-    <access origin="*" />
-    <allow-intent href="http://*/*" />
-    <allow-intent href="https://*/*" />
-    <allow-intent href="tel:*" />
-    <allow-intent href="sms:*" />
-    <allow-intent href="mailto:*" />
-    <allow-intent href="geo:*" />
 </widget>

--- a/template/config.xml
+++ b/template/config.xml
@@ -19,6 +19,20 @@
 # under the License.
 #
 -->
-<widget xmlns="http://www.w3.org/ns/widgets">
-    
+<widget id="io.cordova.hellocordova" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+	<name>HelloCordova</name>
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
+        Apache Cordova Team
+    </author>
+    <content src="index.html" />
+    <access origin="*" />
+    <allow-intent href="http://*/*" />
+    <allow-intent href="https://*/*" />
+    <allow-intent href="tel:*" />
+    <allow-intent href="sms:*" />
+    <allow-intent href="mailto:*" />
+    <allow-intent href="geo:*" />
 </widget>

--- a/template/config.xml
+++ b/template/config.xml
@@ -21,4 +21,10 @@
 -->
 <widget id="io.cordova.hellocordova" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
 	<name>HelloCordova</name>
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
+        Apache Cordova Team
+    </author>
 </widget>

--- a/template/cordova/prepare
+++ b/template/cordova/prepare
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+var Api = require('./Api');
+var nopt = require('nopt');
+var path = require('path');
+var ConfigParser = require('cordova-common').ConfigParser;
+
+// Support basic help commands
+if(['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) >= 0) {
+    console.log('Usage: \n    prepare\n');
+    process.exit(0);
+}
+
+// Do some basic argument parsing
+var opts = nopt({
+    'verbose' : Boolean,
+    'silent' : Boolean
+}, { 'd' : '--verbose' });
+
+// Make buildOptions compatible with PlatformApi clean method spec
+opts.argv = opts.argv.original;
+
+// Skip cleaning prepared files when not invoking via cordova CLI.
+opts.noPrepare = true;
+
+require('./lib/loggingHelper').adjustLoggerLevel(opts);
+
+var projectRoot = path.join(__dirname, '..');
+var project = {
+    root: projectRoot,
+    projectConfig: new ConfigParser(path.join(projectRoot, 'config.xml')),
+    locations: {
+        plugins: path.join(projectRoot, 'plugins'),
+        www: path.join(projectRoot, 'platform_www')
+    }
+};
+
+new Api().prepare(project, opts)
+.catch(function(err) {
+    console.error(err.stack);
+    process.exit(2);
+});

--- a/template/cordova/prepare
+++ b/template/cordova/prepare
@@ -50,7 +50,7 @@ var project = {
     projectConfig: new ConfigParser(path.join(projectRoot, 'config.xml')),
     locations: {
         plugins: path.join(projectRoot, 'plugins'),
-        www: path.join(projectRoot, 'platform_www')
+        www: path.join(projectRoot, 'www')
     }
 };
 

--- a/template/cordova/prepare.bat
+++ b/template/cordova/prepare.bat
@@ -1,0 +1,25 @@
+:: Licensed to the Apache Software Foundation (ASF) under one
+:: or more contributor license agreements.  See the NOTICE file
+:: distributed with this work for additional information
+:: regarding copyright ownership.  The ASF licenses this file
+:: to you under the Apache License, Version 2.0 (the
+:: "License"); you may not use this file except in compliance
+:: with the License.  You may obtain a copy of the License at
+:: 
+:: http://www.apache.org/licenses/LICENSE-2.0
+:: 
+:: Unless required by applicable law or agreed to in writing,
+:: software distributed under the License is distributed on an
+:: "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+:: KIND, either express or implied.  See the License for the
+:: specific language governing permissions and limitations
+:: under the License
+@ECHO OFF
+SET script_path="%~dp0prepare"
+IF EXIST %script_path% (
+        node %script_path% %*
+) ELSE (
+    ECHO.
+    ECHO ERROR: Could not find 'preapre' script in 'cordova' folder, aborting...>&2
+    EXIT /B 1
+)


### PR DESCRIPTION
… to prepare project files

(based on `clean` and some terrible code to build a `project` object)
also adds default `config.xml` as in other projects

replaces #250

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
