### PR TITLE
CB-13870 Improve check_reqs

### DIFF
--- a/bin/check_all
+++ b/bin/check_all
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+var check_reqs = require('./lib/check_reqs');
+
+// check for help flag
+if (['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) > -1) {
+    check_reqs.help();
+} else {
+  check_reqs.check_all().done(function success(result) {
+      console.log('check_all', result);
+  }, function (err) {
+      console.error('Error: ' + err);
+      process.exit(2);
+  });
+}

--- a/bin/check_all.bat
+++ b/bin/check_all.bat
@@ -1,0 +1,25 @@
+:: Licensed to the Apache Software Foundation (ASF) under one
+:: or more contributor license agreements.  See the NOTICE file
+:: distributed with this work for additional information
+:: regarding copyright ownership.  The ASF licenses this file
+:: to you under the Apache License, Version 2.0 (the
+:: "License"); you may not use this file except in compliance
+:: with the License.  You may obtain a copy of the License at
+:: 
+:: http://www.apache.org/licenses/LICENSE-2.0
+:: 
+:: Unless required by applicable law or agreed to in writing,
+:: software distributed under the License is distributed on an
+:: "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+:: KIND, either express or implied.  See the License for the
+:: specific language governing permissions and limitations
+:: under the License
+@ECHO OFF
+SET script_path="%~dp0check_all"
+IF EXIST %script_path% (
+        node "%script_path%" %*
+) ELSE (
+    ECHO.
+    ECHO ERROR: Could not find 'check_all' script in 'bin' folder, aborting...>&2
+    EXIT /B 1
+)

--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -339,7 +339,7 @@ var checkPhoneSdk = function (windowsTargetVersion, windowsPhoneTargetVersion) {
 };
 
 module.exports.run = function () {
-    return checkOS().then(function () {
+    return checkOS('10.0', '10.0').then(function () {
         return MSBuildTools.findAvailableVersion();
     });
 };

--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -388,8 +388,15 @@ function getConfig () {
         config = config || new ConfigParser(path.join(__dirname, '../../config.xml'));
         return Q(config);
     } catch (e) {
-        return Q.reject(new CordovaError('Can\'t check requirements for Windows platform.' +
-            'The config.xml file is either missing or malformed.'));
+        // try again to cover case of being called from command line
+        try {
+            config = config || new ConfigParser(path.join(__dirname, '../../template/config.xml'));
+            return Q(config);
+        } catch (e) {
+            // yeah, really no config.xml
+            return Q.reject(new CordovaError('Can\'t check requirements for Windows platform.' +
+                'The config.xml file is either missing or malformed.'));
+        }
     }
 }
 

--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -287,7 +287,7 @@ var checkVS = function (windowsTargetVersion, windowsPhoneTargetVersion) {
     var vsRequiredVersion = getMinimalRequiredVersionFor('visualstudio', windowsTargetVersion, windowsPhoneTargetVersion);
 
     if (process.env.VSINSTALLDIR) {
-        return Q('(user-specified)');
+        return Q('(user-specified via VSINSTALLDIR)');
     }
     return getInstalledVSVersions()
         .then(function (installedVersions) {


### PR DESCRIPTION
- New command line script `check_all` that does the same thing as `cordova requirements windows`
- Fix check_reqs to work again (by pinning it to 10.0)

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
