### PR TITLE
CB-13878 MSBUILDDIR env variable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,13 +19,19 @@
 # appveyor file
 # http://www.appveyor.com/docs/appveyor-yml
 
-image:
-- Visual Studio 2015
-- Visual Studio 2017
 environment:
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - nodejs_version: "6"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - nodejs_version: "4"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - nodejs_version: "4"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,10 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - nodejs_version: "6"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      MSBUILDDIR: "C:\\Program Files (x86)\\MSBuild\\14.0\\bin\\"
+
+    - nodejs_version: "6"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - nodejs_version: "4"

--- a/spec/unit/build.spec.js
+++ b/spec/unit/build.spec.js
@@ -371,7 +371,7 @@ describe('run method', function () {
             });
     });
 
-    it('spec.14 should use user-specified msbuild if VSINSTALLDIR variable is set', function (done) {
+    it('spec.14a should use user-specified msbuild if VSINSTALLDIR variable is set', function (done) {
         var customMSBuildPath = '/some/path';
         var msBuildBinPath = path.join(customMSBuildPath, 'MSBuild/15.0/Bin');
         var customMSBuildVersion = '15.0';
@@ -392,6 +392,30 @@ describe('run method', function () {
                 expect(fail).not.toHaveBeenCalled();
                 expect(MSBuildTools.getMSBuildToolsAt).toHaveBeenCalledWith(msBuildBinPath);
                 delete process.env.VSINSTALLDIR;
+                done();
+            });
+    });
+
+    it('spec.14b should use user-specified msbuild if MSBUILDDIR variable is set', function (done) {
+        var msBuildBinPath = path.join('/some/path', 'MSBuild/15.0/Bin');
+        var customMSBuildVersion = '15.0';
+        process.env.MSBUILDDIR = msBuildBinPath;
+
+        spyOn(MSBuildTools, 'getMSBuildToolsAt')
+            .and.returnValue(Q({
+                path: msBuildBinPath,
+                version: customMSBuildVersion,
+                buildProject: jasmine.createSpy('buildProject').and.returnValue(Q())
+            }));
+
+        var fail = jasmine.createSpy('fail');
+
+        build.run({})
+            .fail(fail)
+            .finally(function () {
+                expect(fail).not.toHaveBeenCalled();
+                expect(MSBuildTools.getMSBuildToolsAt).toHaveBeenCalledWith(msBuildBinPath);
+                delete process.env.MSBUILDDIR;
                 done();
             });
     });

--- a/spec/unit/build.spec.js
+++ b/spec/unit/build.spec.js
@@ -376,6 +376,9 @@ describe('run method', function () {
         var msBuildBinPath = path.join(customMSBuildPath, 'MSBuild/15.0/Bin');
         var customMSBuildVersion = '15.0';
         process.env.VSINSTALLDIR = customMSBuildPath;
+        // avoid crosspollution with MSBUILDDIR
+        var backupMSBUILDDIR = process.env.MSBUILDDIR;
+        delete process.env.MSBUILDDIR;
 
         spyOn(MSBuildTools, 'getMSBuildToolsAt')
             .and.returnValue(Q({
@@ -392,6 +395,7 @@ describe('run method', function () {
                 expect(fail).not.toHaveBeenCalled();
                 expect(MSBuildTools.getMSBuildToolsAt).toHaveBeenCalledWith(msBuildBinPath);
                 delete process.env.VSINSTALLDIR;
+                process.env.MSBUILDDIR = backupMSBUILDDIR;
                 done();
             });
     });
@@ -400,6 +404,9 @@ describe('run method', function () {
         var msBuildBinPath = path.join('/some/path', 'MSBuild/15.0/Bin');
         var customMSBuildVersion = '15.0';
         process.env.MSBUILDDIR = msBuildBinPath;
+        // avoid crosspollution with VSINSTALLDIR
+        var backupVSINSTALLDIR = process.env.VSINSTALLDIR;
+        delete process.env.VSINSTALLDIR;
 
         spyOn(MSBuildTools, 'getMSBuildToolsAt')
             .and.returnValue(Q({
@@ -416,6 +423,7 @@ describe('run method', function () {
                 expect(fail).not.toHaveBeenCalled();
                 expect(MSBuildTools.getMSBuildToolsAt).toHaveBeenCalledWith(msBuildBinPath);
                 delete process.env.MSBUILDDIR;
+                process.env.VSINSTALLDIR = backupVSINSTALLDIR;
                 done();
             });
     });

--- a/template/cordova/lib/MSBuildTools.js
+++ b/template/cordova/lib/MSBuildTools.js
@@ -68,6 +68,7 @@ MSBuildTools.prototype.buildProject = function (projFile, buildType, buildarch, 
     }
 
     return promise.then(function () {
+        console.log('buildProject spawn:', path.join(that.path, 'msbuild'), [projFile].concat(args), { stdio: 'inherit' });
         return spawn(path.join(that.path, 'msbuild'), [projFile].concat(args), { stdio: 'inherit' });
     });
 };

--- a/template/cordova/lib/MSBuildTools.js
+++ b/template/cordova/lib/MSBuildTools.js
@@ -75,9 +75,28 @@ MSBuildTools.prototype.buildProject = function (projFile, buildType, buildarch, 
 // check_reqs.js -> checkMSBuild()
 module.exports.findAllAvailableVersions = function () {
     console.log('findAllAvailableVersions');
+
+    var msBuildPath = '';
+
+    // Use MSBUILDDIR environment variable if defined to find MSBuild.
+    // MSBUILDDIR = C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin
+    // MSBUILDDIR = C:\Program Files (x86)\MSBuild\14.0\bin\
+    if (process.env.MSBUILDDIR) {
+        console.log('ENV var MSBUILDDIR is set', process.env.MSBUILDDIR);
+        msBuildPath = process.env.MSBUILDDIR;
+        return module.exports.getMSBuildToolsAt(msBuildPath)
+            .then(function (msBuildTools) {
+                return [msBuildTools];
+            })
+            // If MSBUILDDIR is not specified or doesn't contain a valid MSBuild
+            // - fall back to default discovery mechanism.
+            .catch(findAllAvailableVersionsFallBack);
+    }
+
     // CB-11548 use VSINSTALLDIR environment if defined to find MSBuild.
     if (process.env.VSINSTALLDIR) {
-        var msBuildPath = path.join(process.env.VSINSTALLDIR, 'MSBuild/15.0/Bin');
+        console.log('ENV var VSINSTALLDIR is set', process.env.VSINSTALLDIR);
+        msBuildPath = path.join(process.env.VSINSTALLDIR, 'MSBuild/15.0/Bin');
         return module.exports.getMSBuildToolsAt(msBuildPath)
             .then(function (msBuildTools) {
                 return [msBuildTools];


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?

Adds a MSBUILDDIR env var to influence the MSBuildTools selection process by providing a direct path to it. 

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
