### PR TITLE
CB-14224 Default.rd.xml updates (6.0.x patch)

### DIFF
--- a/template/Properties/Default.rd.xml
+++ b/template/Properties/Default.rd.xml
@@ -13,6 +13,31 @@
 
     Using the Namespace directive to apply reflection policy to all the types in a particular namespace
     <Namespace Name="DataClasses.ViewModels" Seralize="All" />
+
+    The MIT License (MIT)
+
+    Copyright (c) Microsoft Corporation
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+    Source:
+    https://github.com/Microsoft/Windows-universal-samples/blob/master/SharedContent/cs/Default.rd.xml
 -->
 
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Original issue

<https://issues.apache.org/jira/browse/CB-14224>

### Platforms affected

Windows

### What does this PR do?

Proposed `template/Properties/Default.rd.xml` updates in 6.0.x patch release, as rebased & squashed from #284:
- add MIT license text from <https://github.com/Microsoft/Windows-universal-samples>, with left aligment fixed
- add link to <https://github.com/Microsoft/Windows-universal-samples/blob/master/SharedContent/cs/Default.rd.xml>

As I said in #284 I think this is desired to satisfy the Apache RAT tool (used by `coho audit-license-headers`). Alternative may be to add an exception for this file but I think it would be better to follow the standard Apache procedure if possible.

### What testing has been done on this change?

I verified that `coho audit-license-headers -r windows` with these changes does not show the missing license header any more.

### Checklist

- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- ~~Added automated test coverage as appropriate for this change.~~