### PR TITLE
CB-14075: (windows) Remove Node 4 from CI - cordova-windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 language: node_js
 sudo: false
+
 git:
   depth: 10
+
 node_js:
-  - "4"
   - "6"
+  - "8"
+  - "10"
+
 install:
-    - npm install
-    - npm install -g codecov
+  - npm install
+  - npm install -g codecov
+
 script:
-    - npm run eslint
-    - npm run cover
+  - npm run eslint
+  - npm run cover
+
 after_script:
-    - codecov
+  - codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,12 +31,6 @@ environment:
     - nodejs_version: "6"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - nodejs_version: "4"
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-    - nodejs_version: "4"
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
 matrix:
   allow_failures:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
     "jasmine": "^2.99.0",
     "rewire": "^2.5.1"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
+  "engineStrict": true,
   "bundledDependencies": [
     "cordova-common",
     "elementtree",


### PR DESCRIPTION
### Platforms affected
windows

### What does this PR do?
- Drops Node 4 support from Travis CI and AppVeyor.
- Adds Node 8 and 10 to Travis CI.
- Adds node node engine requirement flag to package.json

### What testing has been done on this change?
**Travis CI**
- https://travis-ci.org/erisu/cordova-windows/builds/411112975

**AppVeyor**
- https://ci.appveyor.com/project/erisu/cordova-windows/build/1.0.2

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
