### PR TITLE
Only copy platform node_modules when created by binary

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -51,7 +51,8 @@ if (argv.argv.remain[2]) config.setName(argv.argv.remain[2]);
 
 var options = {
     guid: argv.guid,
-    customTemplate: argv.argv.remain[3]
+    customTemplate: argv.argv.remain[3],
+    copyPlatformNodeModules: true
 };
 
 require('../template/cordova/lib/loggingHelper').adjustLoggerLevel(options);

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -74,7 +74,7 @@ module.exports.create = function (destinationDir, config, options) {
 
     // copy node_modules to cordova directory
     events.emit('verbose', 'Copying node_modules to ' + projectPath);
-    shell.cp('-r', path.join(root, 'node_modules'), path.join(projectPath, 'cordova'));
+    if (options.copyPlatformNodeModules) shell.cp('-r', path.join(root, 'node_modules'), path.join(projectPath, 'cordova'));
 
     // copy check_reqs module to cordova directory
     shell.cp('-rf', path.join(root, 'bin', 'check_reqs*'), path.join(projectPath, 'cordova'));


### PR DESCRIPTION
### Platforms affected
windows

### What does this PR do?
When platform is installed though CLI, `cordova platform add windows`, the copy node_modules step is no longer valid as dependencies are now at the project level.

The step is required only when the create binary from the platform repo is called.

https://github.com/apache/cordova/issues/32

### What testing has been done on this change?
- npm run eslint
- npm run test-unit
- https://travis-ci.org/erisu/cordova-windows/builds/452156079
- https://ci.appveyor.com/project/erisu/cordova-windows/builds/20133663