### PR TITLE
Dependency bump cordova-common@^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint": "eslint bin && eslint template && eslint spec"
   },
   "dependencies": {
-    "cordova-common": "^2.2.1",
+    "cordova-common": "^3.0.0",
     "elementtree": "^0.1.7",
     "node-uuid": "^1.4.8",
     "nopt": "^3.0.4",


### PR DESCRIPTION
### Platforms affected
windows

### What does this PR do?
Updates the cordova-common dependency to ^3.0.0.

### What testing has been done on this change?
- Travis CI Testing: https://travis-ci.org/erisu/cordova-windows/builds/452164116
- Appveyor Testing: https://ci.appveyor.com/project/erisu/cordova-windows/builds/20134203