### PR TITLE
Windows Platform Release Preparation (Cordova 9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ npm-debug.log
 # Skip testing stuff
 coverage/*
 testcreate*
+coverage/
+.nyc_output/

--- a/bin/lib/update.js
+++ b/bin/lib/update.js
@@ -53,5 +53,5 @@ module.exports.update = function (destinationDir, options) {
     } catch (e) { /* ignore IO errors */ }
 
     shell.rm('-rf', destinationDir);
-    return create.create(destinationDir, config, {guid: guid}, events);
+    return create.create(destinationDir, config, { guid: guid }, events);
 };

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
     "winjs": "^4.4.3"
   },
   "devDependencies": {
-    "eslint": "^4.18.0",
-    "eslint-config-semistandard": "^11.0.0",
-    "eslint-config-standard": "^10.2.1",
-    "eslint-plugin-import": "^2.3.0",
-    "eslint-plugin-node": "^5.0.0",
-    "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^3.0.1",
+    "eslint": "^5.12.0",
+    "eslint-config-semistandard": "^13.0.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
     "istanbul": "^0.4.0",
     "jasmine": "^2.99.0",
     "rewire": "^2.5.1"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cordova-common": "^3.1.0",
     "elementtree": "^0.1.7",
     "node-uuid": "^1.4.8",
-    "nopt": "^3.0.4",
+    "nopt": "^4.0.1",
     "q": "^1.5.1",
     "semver": "^5.5.0",
     "shelljs": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint": "eslint bin && eslint template && eslint spec"
   },
   "dependencies": {
-    "cordova-common": "^3.0.0",
+    "cordova-common": "^3.1.0",
     "elementtree": "^0.1.7",
     "node-uuid": "^1.4.8",
     "nopt": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "istanbul": "^0.4.0",
-    "jasmine": "^2.99.0",
-    "rewire": "^2.5.1"
+    "jasmine": "3.1.0",
+    "rewire": "^4.0.1"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "npm run eslint && npm run test-unit && npm run test-e2e",
     "test-unit": "jasmine",
     "test-e2e": "jasmine spec/e2e/endtoend.spec.js",
-    "cover": "istanbul cover --root bin/templates/cordova --print detail jasmine",
+    "cover": "nyc jasmine",
     "eslint": "eslint bin && eslint template && eslint spec"
   },
   "dependencies": {
@@ -41,8 +41,8 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "istanbul": "^0.4.0",
     "jasmine": "3.1.0",
+    "nyc": "^13.1.0",
     "rewire": "^4.0.1"
   },
   "engines": {
@@ -50,5 +50,15 @@
   },
   "engineStrict": true,
   "author": "Apache Software Foundation",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "nyc": {
+    "include": [
+      "bin/**",
+      "template/cordova/**"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ]
+  }
 }

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -61,8 +61,8 @@ describe('Cordova create and build', function () {
     }
 
     beforeEach(function () {
-        shell.exec(path.join('bin', 'create') + ' "' + projectFolder + '" com.test.app 応用', {silent: silent});
-        shell.exec(prepareScriptPath + '', {silent: silent});
+        shell.exec(path.join('bin', 'create') + ' "' + projectFolder + '" com.test.app 応用', { silent: silent });
+        shell.exec(prepareScriptPath + '', { silent: silent });
     });
 
     afterEach(function () {
@@ -77,34 +77,34 @@ describe('Cordova create and build', function () {
     // default
 
     it('spec.2a should build default (win10) project', function () {
-        shell.exec(buildScriptPath + '', {silent: silent});
+        shell.exec(buildScriptPath + '', { silent: silent });
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
 
     // --appx
 
     it('spec.2b should build uap (win10) project', function () {
-        shell.exec(buildScriptPath + ' --appx=uap', {silent: silent});
+        shell.exec(buildScriptPath + ' --appx=uap', { silent: silent });
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
 
     it('spec.2c should build uwp (win10) project', function () {
-        shell.exec(buildScriptPath + ' --appx=uwp', {silent: silent});
+        shell.exec(buildScriptPath + ' --appx=uwp', { silent: silent });
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
 
     it('spec.2d should build 8.1 win project', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1-win', {silent: silent});
+        shell.exec(buildScriptPath + ' --appx=8.1-win', { silent: silent });
         _expectExist(/.*Windows.*\.appxupload/);
     });
 
     it('spec.2e should build 8.1 phone project', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1-phone', {silent: silent});
+        shell.exec(buildScriptPath + ' --appx=8.1-phone', { silent: silent });
         _expectExist(/.*Phone.*\.appxupload/);
     });
 
     it('spec.2f should build 8.1 win + phone project', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1', {silent: silent});
+        shell.exec(buildScriptPath + ' --appx=8.1', { silent: silent });
         _expectExist(/.*Windows.*\.appxupload/);
         _expectExist(/.*Phone.*\.appxupload/);
     });
@@ -112,28 +112,28 @@ describe('Cordova create and build', function () {
     // --archs
 
     it('spec.3a should build project for particular CPU', function () {
-        shell.exec(buildScriptPath + ' --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
+        shell.exec(buildScriptPath + ' --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x64_debug.appx');
     });
 
     it('spec.3b should build project (8.1) for particular CPU', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
+        shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
         _expectExist(/.*Phone.*x64.*\.appxupload/);
         _expectExist(/.*Windows.*x64.*\.appxupload/);
     });
 
     it('spec.3c should build project (8.1-win) for particular CPU', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1-win --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
+        shell.exec(buildScriptPath + ' --appx=8.1-win --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
         _expectExist(/.*Windows.*x64.*\.appxupload/);
     });
 
     it('spec.3d should build project (8.1-phone) for particular CPU', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1-phone --archs=\"x64\"', {silent: silent}); /* eslint no-useless-escape : 0 */
+        shell.exec(buildScriptPath + ' --appx=8.1-phone --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
         _expectExist(/.*Phone.*x64.*\.appxupload/);
     });
 
     it('spec.4a should build project for CPUs separated by whitespaces', function () {
-        shell.exec(buildScriptPath + ' --archs=\"x64 x86 arm anycpu\"', {silent: silent}); /* eslint no-useless-escape : 0 */
+        shell.exec(buildScriptPath + ' --archs=\"x64 x86 arm anycpu\"', { silent: silent }); /* eslint no-useless-escape : 0 */
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x64_debug.appx');
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x86_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x86_debug.appx');
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_arm_debug_Test', 'CordovaApp.Windows10_1.0.0.0_arm_debug.appx');
@@ -141,7 +141,7 @@ describe('Cordova create and build', function () {
     });
 
     it('spec.4b should build project (8.1) for CPUs separated by whitespaces', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64 x86 arm anycpu\"', {silent: silent}); /* eslint no-useless-escape : 0 */
+        shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64 x86 arm anycpu\"', { silent: silent }); /* eslint no-useless-escape : 0 */
         _expectExist(/.*Phone.*x86.*\.appxupload/);
         _expectExist(/.*Phone.*x64.*\.appxupload/);
         _expectExist(/.*Phone.*arm.*\.appxupload/);
@@ -170,7 +170,7 @@ describe('Cordova create and build', function () {
 
         api.addPlugin(extensionsPluginInfo)
             .then(function () {
-                shell.exec(buildScriptPath, {silent: silent});
+                shell.exec(buildScriptPath, { silent: silent });
                 _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
             })
             .catch(fail)
@@ -196,7 +196,7 @@ describe('Cordova create and build', function () {
 
         api.addPlugin(extensionsPluginInfo)
             .then(function () {
-                shell.exec(buildScriptPath + ' --appx=8.1', {silent: silent});
+                shell.exec(buildScriptPath + ' --appx=8.1', { silent: silent });
                 _expectExist(/.*Windows.*\.appxupload/);
                 _expectExist(/.*Phone.*\.appxupload/);
             })
@@ -212,7 +212,7 @@ describe('Cordova create and build', function () {
     // here be 6a
 
     it('spec.6b should generate appxupload and appxbundle for Windows Phone 8.1 project bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --appx=8.1-phone --bundle --archs=\"x64 x86 arm\"', {silent: silent});
+        shell.exec(buildScriptPath + ' --release --appx=8.1-phone --bundle --archs=\"x64 x86 arm\"', { silent: silent });
         _expectExist(/.*bundle\.appxupload$/, 3);
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_Test', 'CordovaApp.Phone_1.0.0.0_x64_x86_arm.appxbundle');
     });
@@ -220,7 +220,7 @@ describe('Cordova create and build', function () {
     // --release (non-bundle)
 
     it('spec.7 should generate appxupload for Windows 10 project non-bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --archs=\"x64 x86 arm\"', {silent: silent});
+        shell.exec(buildScriptPath + ' --release --archs=\"x64 x86 arm\"', { silent: silent });
         _expectExist(/.*\.appxupload$/, 3);
         // CB-12416 Should build appx in separate dirs for each architecture
         // Should contain a subdirectory for each of the architectures
@@ -231,7 +231,7 @@ describe('Cordova create and build', function () {
     });
 
     it('spec.8 for a non-bundle case for Windows Phone 8.1 it should build appx in separate dirs for each architecture', function () {
-        shell.exec(buildScriptPath + ' --release --appx=8.1-phone --phone --archs=\"x86 arm\"', {silent: silent});
+        shell.exec(buildScriptPath + ' --release --appx=8.1-phone --phone --archs=\"x86 arm\"', { silent: silent });
         _expectExist(/.*\.appxupload$/, 2);
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_arm_Test', 'CordovaApp.Phone_1.0.0.0_arm.appx');
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_x86_Test', 'CordovaApp.Phone_1.0.0.0_x86.appx');
@@ -239,7 +239,7 @@ describe('Cordova create and build', function () {
 
     // this will be move up again when it is fixed for VS 2017 on AppVeyor
     it('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', {silent: silent});
+        shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', { silent: silent });
         _expectExist(/.*bundle\.appxupload$/, 3);
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_Test', 'CordovaApp.Windows10_1.0.0.0_x64_x86_arm.appxbundle');
     });

--- a/spec/unit/ConfigChanges.spec.js
+++ b/spec/unit/ConfigChanges.spec.js
@@ -49,7 +49,7 @@ describe('PlatformMunger', function () {
         shell.mkdir('-p', tempDir);
         munge = { parents: { 'foo/bar': [
             { before: undefined, count: 1, xml: '<DummyElement name="Dummy" />' }
-        ]}};
+        ] } };
         munger = new PlatformMunger('windows', tempDir);
         spyOn(BaseMunger.prototype, 'apply_file_munge').and.callThrough();
     });
@@ -76,12 +76,12 @@ describe('PlatformMunger', function () {
                 // Emulate capability that was initially added with uap prefix
                 { before: undefined, count: 1, xml: '<uap:Capability Name=\"privateNetworkClientServer\">' }, /* eslint no-useless-escape : 0 */
                 { before: undefined, count: 1, xml: '<Capability Name=\"enterpriseAuthentication\">' } /* eslint no-useless-escape : 0 */
-            ]}};
+            ] } };
 
             var capabilitiesMunge = { parents: { '/Package/Capabilities': [
                 { before: undefined, count: 1, xml: '<uap:Capability Name=\"privateNetworkClientServer\">' },
                 { before: undefined, count: 1, xml: '<uap:Capability Name=\"enterpriseAuthentication\">' }
-            ]}};
+            ] } };
             munger.apply_file_munge(WINDOWS10_MANIFEST, baseMunge, /* remove= */true);
             expect(BaseMunger.prototype.apply_file_munge).toHaveBeenCalledWith(WINDOWS10_MANIFEST, capabilitiesMunge, true);
         });

--- a/spec/unit/build.spec.js
+++ b/spec/unit/build.spec.js
@@ -86,7 +86,7 @@ describe('run method', function () {
         var originalBuildMethod = build.run;
         spyOn(build, 'run').and.callFake(function () {
             // Bind original build to custom 'this' object to mock platform's locations property
-            return originalBuildMethod.apply({locations: {www: 'some/path'}}, arguments);
+            return originalBuildMethod.apply({ locations: { www: 'some/path' } }, arguments);
         });
 
         spyOn(utils, 'isCordovaProject').and.returnValue(true);
@@ -131,7 +131,7 @@ describe('run method', function () {
         createFindAvailableVersionMock('14.0', testPath, buildSpy);
 
         expect(function () {
-            build.run({release: true, debug: true});
+            build.run({ release: true, debug: true });
         }).toThrow();
     });
 
@@ -141,7 +141,7 @@ describe('run method', function () {
         createFindAvailableVersionMock('14.0', testPath, buildSpy);
 
         expect(function () {
-            build.run({argv: [ '--phone', '--win' ]});
+            build.run({ argv: [ '--phone', '--win' ] });
         }).toThrow();
     });
 
@@ -261,7 +261,7 @@ describe('run method', function () {
         createFindAllAvailableVersionsMock([{ version: '4.0', buildProject: buildSpy, path: testPath }]);
         createConfigParserMock('8.0');
 
-        build.run({argv: ['--win']})
+        build.run({ argv: ['--win'] })
             .fail(function (error) {
                 errorSpy();
                 expect(error).toBeDefined();
@@ -279,7 +279,7 @@ describe('run method', function () {
         createFindAllAvailableVersionsMock([{ version: '14.0', buildProject: buildSpy, path: testPath }]);
         createConfigParserMock('8.1');
 
-        build.run({argv: ['--win']})
+        build.run({ argv: ['--win'] })
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
                 done();
@@ -293,7 +293,7 @@ describe('run method', function () {
         createFindAvailableVersionMock('14.0', testPath, buildSpy);
         createConfigParserMock('unsupported value here');
 
-        build.run({argv: ['--win']})
+        build.run({ argv: ['--win'] })
             .fail(function (error) {
                 errorSpy();
                 expect(error).toBeDefined();
@@ -311,7 +311,7 @@ describe('run method', function () {
         createFindAllAvailableVersionsMock([{ version: '14.0', buildProject: buildSpy, path: testPath }]);
         createConfigParserMock(null, '8.1');
 
-        build.run({argv: ['--phone']})
+        build.run({ argv: ['--phone'] })
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
                 done();
@@ -325,7 +325,7 @@ describe('run method', function () {
         createFindAvailableVersionMock('14.0', testPath, buildSpy);
         createConfigParserMock(null, 'unsupported value here');
 
-        build.run({argv: ['--phone']})
+        build.run({ argv: ['--phone'] })
             .fail(function (error) {
                 errorSpy();
                 expect(error).toBeDefined();
@@ -347,7 +347,7 @@ describe('run method', function () {
         // provision config to target Windows 8.1
         createConfigParserMock('8.1', '8.1');
         // explicitly specify Windows 10 as target
-        build.run({argv: ['--appx=uap']})
+        build.run({ argv: ['--appx=uap'] })
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
                 done();
@@ -364,7 +364,7 @@ describe('run method', function () {
         // provision config to target Windows 8.1
         createConfigParserMock('8.1', '8.1');
         // explicitly specify Windows 10 as target
-        build.run({argv: ['--appx=uwp']})
+        build.run({ argv: ['--appx=uwp'] })
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
                 done();
@@ -436,7 +436,7 @@ describe('run method', function () {
 
         createFindAllAvailableVersionsMock([buildTools14, buildTools15, buildTools151]);
         // explicitly specify Windows 10 as target
-        build.run({argv: ['--appx=uap']})
+        build.run({ argv: ['--appx=uap'] })
             .fail(fail)
             .finally(function () {
                 expect(fail).not.toHaveBeenCalled();
@@ -453,7 +453,7 @@ describe('run method', function () {
 
         createFindAllAvailableVersionsMock([buildTools14, buildTools15, buildTools151]);
         // explicitly specify Windows 10 as target
-        build.run({argv: ['--appx=uwp']})
+        build.run({ argv: ['--appx=uwp'] })
             .fail(fail)
             .finally(function () {
                 expect(fail).not.toHaveBeenCalled();

--- a/spec/unit/pluginHandler/windows.spec.js
+++ b/spec/unit/pluginHandler/windows.spec.js
@@ -463,7 +463,7 @@ describe('windows project handler', function () {
         });
 
         describe('of <js-module> elements', function () {
-            var jsModule = {src: 'www/dummyplugin.js'};
+            var jsModule = { src: 'www/dummyplugin.js' };
             var wwwDest, platformWwwDest;
 
             var install = PluginHandler.getInstaller('js-module');
@@ -475,7 +475,7 @@ describe('windows project handler', function () {
             });
 
             it('Test #028 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
-                install(jsModule, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                install(jsModule, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(fs.writeFileSync).toHaveBeenCalledWith(wwwDest, jasmine.any(String), 'utf-8');
                 expect(fs.writeFileSync).toHaveBeenCalledWith(platformWwwDest, jasmine.any(String), 'utf-8');
             });
@@ -488,7 +488,7 @@ describe('windows project handler', function () {
         });
 
         describe('of <asset> elements', function () {
-            var asset = {src: 'www/dummyplugin.js', target: 'foo/dummy.js'};
+            var asset = { src: 'www/dummyplugin.js', target: 'foo/dummy.js' };
             var wwwDest; /* eslint no-unused-vars : 0 */
             var platformWwwDest; /* eslint no-unused-vars : 0 */
             var install = PluginHandler.getInstaller('asset');
@@ -500,7 +500,7 @@ describe('windows project handler', function () {
             });
 
             it('Test #029 : should put asset to both www and platform_www when options.usePlatformWww flag is specified', function () {
-                install(asset, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                install(asset, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyPluginInfo.dir, asset.src, dummyProject.www, asset.target);
                 expect(copyFileSpy).toHaveBeenCalledWith(dummyPluginInfo.dir, asset.src, dummyProject.platformWww, asset.target);
             });
@@ -586,7 +586,7 @@ describe('windows project handler', function () {
                 });
                 var path = 'ItemGroup/Content';
                 var incText = resourcefiles[0].target;
-                var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x86'};
+                var targetConditions = { versions: undefined, deviceTarget: undefined, arch: 'x86' };
                 validateUninstalledProjects('resource-file', resourcefiles[0], path, incText, targetConditions, ['all']);
             });
 
@@ -598,7 +598,7 @@ describe('windows project handler', function () {
                 });
                 var path = 'ItemGroup/Content';
                 var incText = resourcefiles[1].target;
-                var targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
+                var targetConditions = { versions: '>=8.1', deviceTarget: undefined, arch: undefined };
                 validateUninstalledProjects('resource-file', resourcefiles[1], path, incText, targetConditions, ['windows', 'phone', 'windows10']);
             });
 
@@ -610,7 +610,7 @@ describe('windows project handler', function () {
                 });
                 var path = 'ItemGroup/Content';
                 var incText = resourcefiles[2].target;
-                var targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
+                var targetConditions = { versions: undefined, deviceTarget: 'phone', arch: undefined };
                 validateUninstalledProjects('resource-file', resourcefiles[2], path, incText, targetConditions, ['phone']);
             });
 
@@ -621,7 +621,7 @@ describe('windows project handler', function () {
                 });
                 var path = 'ItemGroup/Content';
                 var incText = resourcefiles[3].target;
-                var targetConditions = {versions: '8.0', deviceTarget: 'windows', arch: 'x64'};
+                var targetConditions = { versions: '8.0', deviceTarget: 'windows', arch: 'x64' };
                 validateUninstalledProjects('resource-file', resourcefiles[3], path, incText, targetConditions, ['windows8']);
             });
 
@@ -633,7 +633,7 @@ describe('windows project handler', function () {
                 });
                 var path = 'ItemGroup/Content';
                 var incText = computeResourcePath(resourcereferencefiles[0]);
-                var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x86'};
+                var targetConditions = { versions: undefined, deviceTarget: undefined, arch: 'x86' };
                 validateUninstalledProjects('resource-file', resourcereferencefiles[0], path, incText, targetConditions, ['all']);
             });
             it('Test #036 : should remove from correct project files when conditions specified with reference', function () {
@@ -644,7 +644,7 @@ describe('windows project handler', function () {
                 });
                 var path = 'ItemGroup/Content';
                 var incText = computeResourcePath(resourcereferencefiles[1]);
-                var targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
+                var targetConditions = { versions: '>=8.1', deviceTarget: undefined, arch: undefined };
                 validateUninstalledProjects('resource-file', resourcereferencefiles[1], path, incText, targetConditions, ['windows', 'phone', 'windows10']);
             });
 
@@ -656,7 +656,7 @@ describe('windows project handler', function () {
                 });
                 var path = 'ItemGroup/Content';
                 var incText = computeResourcePath(resourcereferencefiles[2]);
-                var targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
+                var targetConditions = { versions: undefined, deviceTarget: 'phone', arch: undefined };
                 validateUninstalledProjects('resource-file', resourcereferencefiles[2], path, incText, targetConditions, ['phone']);
             });
 
@@ -668,7 +668,7 @@ describe('windows project handler', function () {
                 });
                 var path = 'ItemGroup/Content';
                 var incText = computeResourcePath(resourcereferencefiles[3]);
-                var targetConditions = {versions: '8.0', deviceTarget: 'windows', arch: 'x64'};
+                var targetConditions = { versions: '8.0', deviceTarget: 'windows', arch: 'x64' };
                 validateUninstalledProjects('resource-file', resourcereferencefiles[3], path, incText, targetConditions, ['windows8']);
             });
         });
@@ -684,7 +684,7 @@ describe('windows project handler', function () {
 
                 var path = 'ItemGroup/SDKReference';
                 var incText = 'TestSDK1, Version=1.0';
-                var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x86'};
+                var targetConditions = { versions: undefined, deviceTarget: undefined, arch: 'x86' };
                 validateUninstalledProjects('lib-file', libfiles[0], path, incText, targetConditions, ['all']);
             });
 
@@ -696,7 +696,7 @@ describe('windows project handler', function () {
 
                 var path = 'ItemGroup/SDKReference';
                 var incText = 'TestSDK2, Version=1.0';
-                var targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
+                var targetConditions = { versions: '>=8.1', deviceTarget: undefined, arch: undefined };
                 validateUninstalledProjects('lib-file', libfiles[1], path, incText, targetConditions, ['windows', 'phone', 'windows10']);
             });
 
@@ -708,7 +708,7 @@ describe('windows project handler', function () {
 
                 var path = 'ItemGroup/SDKReference';
                 var incText = 'TestSDK3, Version=1.0';
-                var targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
+                var targetConditions = { versions: undefined, deviceTarget: 'phone', arch: undefined };
                 validateUninstalledProjects('lib-file', libfiles[2], path, incText, targetConditions, ['phone']);
             });
 
@@ -720,7 +720,7 @@ describe('windows project handler', function () {
 
                 var path = 'ItemGroup/SDKReference';
                 var incText = 'TestSDK4, Version=1.0';
-                var targetConditions = {versions: '8.0', deviceTarget: 'windows', arch: 'x86'};
+                var targetConditions = { versions: '8.0', deviceTarget: 'windows', arch: 'x86' };
                 validateUninstalledProjects('lib-file', libfiles[3], path, incText, targetConditions, ['windows8']);
             });
         });
@@ -741,7 +741,7 @@ describe('windows project handler', function () {
 
                 var path2 = 'ItemGroup/Reference';
                 var incText = 'dummy1';
-                var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x64'};
+                var targetConditions = { versions: undefined, deviceTarget: undefined, arch: 'x64' };
                 validateUninstalledProjects('framework', frameworks[0], path2, incText, targetConditions, ['all']);
 
                 process.chdir(path.join(curDir, '..', '..', '..'));
@@ -760,7 +760,7 @@ describe('windows project handler', function () {
 
                 var path2 = 'ItemGroup/Reference';
                 var incText = 'dummy2';
-                var targetConditions = {versions: '>=8.0', deviceTarget: undefined, arch: undefined};
+                var targetConditions = { versions: '>=8.0', deviceTarget: undefined, arch: undefined };
                 validateUninstalledProjects('framework', frameworks[1], path2, incText, targetConditions, ['all']);
                 process.chdir(path.join(curDir, '..', '..', '..'));
             });
@@ -778,7 +778,7 @@ describe('windows project handler', function () {
 
                 var path2 = 'ItemGroup/Reference';
                 var incText = 'dummy3';
-                var targetConditions = {versions: undefined, deviceTarget: 'windows', arch: undefined};
+                var targetConditions = { versions: undefined, deviceTarget: 'windows', arch: undefined };
                 validateUninstalledProjects('framework', frameworks[2], path2, incText, targetConditions, ['windows', 'windows8', 'windows10']);
                 process.chdir(path.join(curDir, '..', '..', '..'));
             });
@@ -796,7 +796,7 @@ describe('windows project handler', function () {
 
                 var path2 = 'ItemGroup/Reference';
                 var incText = 'dummy4';
-                var targetConditions = {versions: '8.1', deviceTarget: 'phone', arch: 'ARM'};
+                var targetConditions = { versions: '8.1', deviceTarget: 'phone', arch: 'ARM' };
                 validateUninstalledProjects('framework', frameworks[3], path2, incText, targetConditions, ['phone']);
                 process.chdir(path.join(curDir, '..', '..', '..'));
             });
@@ -814,7 +814,7 @@ describe('windows project handler', function () {
 
                 var path2 = 'ItemGroup/Reference';
                 var incText = 'dummy5';
-                var targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
+                var targetConditions = { versions: undefined, deviceTarget: 'phone', arch: undefined };
                 validateUninstalledProjects('framework', frameworks[4], path2, incText, targetConditions, ['phone']);
                 process.chdir(path.join(curDir, '..', '..', '..'));
             });
@@ -832,7 +832,7 @@ describe('windows project handler', function () {
 
                 var path2 = 'ItemGroup/Reference';
                 var incText = 'dummy6';
-                var targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
+                var targetConditions = { versions: '>=8.1', deviceTarget: undefined, arch: undefined };
                 validateUninstalledProjects('framework', frameworks[5], path2, incText, targetConditions, ['windows', 'windows10', 'phone']);
 
                 process.chdir(path.join(curDir, '..', '..', '..'));
@@ -855,7 +855,7 @@ describe('windows project handler', function () {
 
                 var xmlPath = 'ItemGroup/ProjectReference';
                 var incText = winJoin('..', '..', 'plugins', dummyPluginInfo.id, frameworks[6].src);
-                var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x64'};
+                var targetConditions = { versions: undefined, deviceTarget: undefined, arch: 'x64' };
                 validateUninstalledProjects('framework', frameworks[6], xmlPath, incText, targetConditions, ['all']);
 
                 process.chdir(path.join(curDir, '..', '..', '..'));
@@ -874,7 +874,7 @@ describe('windows project handler', function () {
                 var xmlPath = 'ItemGroup/ProjectReference';
 
                 var incText = winJoin('..', '..', 'plugins', dummyPluginInfo.id, frameworks[7].src);
-                var targetConditions = {versions: '<8.1', deviceTarget: undefined, arch: undefined};
+                var targetConditions = { versions: '<8.1', deviceTarget: undefined, arch: undefined };
                 validateUninstalledProjects('framework', frameworks[7], xmlPath, incText, targetConditions, ['windows8']);
 
                 process.chdir(path.join(curDir, '..', '..', '..'));
@@ -894,7 +894,7 @@ describe('windows project handler', function () {
                 var xmlPath = 'ItemGroup/ProjectReference';
 
                 var incText = winJoin('..', '..', 'plugins', dummyPluginInfo.id, frameworks[8].src);
-                var targetConditions = {versions: undefined, deviceTarget: 'win', arch: undefined};
+                var targetConditions = { versions: undefined, deviceTarget: 'win', arch: undefined };
                 validateUninstalledProjects('framework', frameworks[8], xmlPath, incText, targetConditions, ['windows', 'windows8', 'windows10']);
 
                 process.chdir(path.join(curDir, '..', '..', '..'));
@@ -914,7 +914,7 @@ describe('windows project handler', function () {
                 var xmlPath = 'ItemGroup/ProjectReference';
 
                 var incText = winJoin('..', '..', 'plugins', dummyPluginInfo.id, frameworks[9].src);
-                var targetConditions = {versions: '8.1', deviceTarget: 'all', arch: 'x86'};
+                var targetConditions = { versions: '8.1', deviceTarget: 'all', arch: 'x86' };
                 validateUninstalledProjects('framework', frameworks[9], xmlPath, incText, targetConditions, ['windows', 'phone']);
 
                 process.chdir(path.join(curDir, '..', '..', '..'));
@@ -922,7 +922,7 @@ describe('windows project handler', function () {
         });
 
         describe('of <js-module> elements', function () {
-            var jsModule = {src: 'www/dummyPlugin.js'};
+            var jsModule = { src: 'www/dummyPlugin.js' };
             var wwwDest, platformWwwDest;
 
             var uninstall = PluginHandler.getUninstaller('js-module');
@@ -941,7 +941,7 @@ describe('windows project handler', function () {
             });
 
             it('Test #047 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
-                uninstall(jsModule, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                uninstall(jsModule, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), wwwDest);
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), platformWwwDest);
             });
@@ -954,7 +954,7 @@ describe('windows project handler', function () {
         });
 
         describe('of <asset> elements', function () {
-            var asset = {src: 'www/dummyPlugin.js', target: 'foo/dummy.js'};
+            var asset = { src: 'www/dummyPlugin.js', target: 'foo/dummy.js' };
             var wwwDest, platformWwwDest;
             var uninstall = PluginHandler.getUninstaller('asset');
 
@@ -972,7 +972,7 @@ describe('windows project handler', function () {
             });
 
             it('Test #049 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
-                uninstall(asset, dummyPluginInfo, dummyProject, {usePlatformWww: true});
+                uninstall(asset, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), wwwDest);
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), platformWwwDest);
             });

--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -256,7 +256,7 @@ describe('run method', function () {
         spyOn(packages, 'deployToDesktop').and.returnValue(Q());
 
         var anyString = jasmine.any(String);
-        var expectedDeployOptions = jasmine.objectContaining({arch: 'arm'});
+        var expectedDeployOptions = jasmine.objectContaining({ arch: 'arm' });
 
         var fail = jasmine.createSpy('fail')
             .and.callFake(function (err) {
@@ -289,11 +289,11 @@ describe('run method', function () {
         spyOn(packages, 'deployToDesktop').and.returnValue(Q());
 
         var anyString = jasmine.any(String);
-        var expectedDeployOptions = jasmine.objectContaining({arch: 'anycpu'});
+        var expectedDeployOptions = jasmine.objectContaining({ arch: 'anycpu' });
 
         var fail = jasmine.createSpy('fail');
 
-        run.run({nobuild: true})
+        run.run({ nobuild: true })
             .then(function () {
                 expect(packages.getPackage).toHaveBeenCalledWith(anyString, anyString, 'anycpu');
                 expect(packages.deployToDesktop).toHaveBeenCalledWith(expectedDeployOptions, anyString, anyString);

--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -361,7 +361,7 @@ AppxManifest.prototype.getApplication = function () {
             application.append(appUriRules);
 
             rules.forEach(function (rule) {
-                appUriRules.append(new et.Element('Rule', {Match: rule, Type: 'include'}));
+                appUriRules.append(new et.Element('Rule', { Match: rule, Type: 'include' }));
             });
 
             return this;
@@ -415,7 +415,7 @@ AppxManifest.prototype.getVisualElements = function () {
 
             var orientations = KNOWN_ORIENTATIONS[orientation] || orientation.split(',');
             orientations.forEach(function (orientation) {
-                var el = new et.Element(self.prefix + 'Rotation', {Preference: orientation});
+                var el = new et.Element(self.prefix + 'Rotation', { Preference: orientation });
                 rotationPreferenceRoot.append(el);
             });
 
@@ -608,7 +608,7 @@ AppxManifest.prototype.setAppName = function (name) {
 AppxManifest.prototype.write = function (destPath) {
     // sort Capability elements as per CB-5350 Windows8 build fails due to invalid 'Capabilities' definition
     sortCapabilities(this.doc);
-    fs.writeFileSync(destPath || this.path, this.doc.write({indent: 4}), 'utf-8');
+    fs.writeFileSync(destPath || this.path, this.doc.write({ indent: 4 }), 'utf-8');
 };
 
 /**
@@ -782,7 +782,7 @@ Win10AppxManifest.prototype.writeToString = function () {
     ensureUniqueCapabilities(this.doc.find('.//Capabilities'));
     // sort Capability elements as per CB-5350 Windows8 build fails due to invalid 'Capabilities' definition
     sortCapabilities(this.doc);
-    return this.doc.write({indent: 4});
+    return this.doc.write({ indent: 4 });
 };
 
 /**

--- a/template/cordova/lib/JsprojManager.js
+++ b/template/cordova/lib/JsprojManager.js
@@ -219,7 +219,7 @@ jsprojManager.prototype = {
 
         // There may be multiple solution files (for different VS versions) - process them all
         getSolutionPaths(this.projectFolder).forEach(function (solutionPath) {
-            var solText = fs.readFileSync(solutionPath, {encoding: 'utf8'});
+            var solText = fs.readFileSync(solutionPath, { encoding: 'utf8' });
 
             if (useProjItems) {
                 // Insert a project dependency into every jsproj in the solution.
@@ -250,7 +250,7 @@ jsprojManager.prototype = {
             pos += 10; // Move pos to the end of EndProject text
             solText = solText.slice(0, pos) + postInsertText + solText.slice(pos);
 
-            fs.writeFileSync(solutionPath, solText, {encoding: 'utf8'});
+            fs.writeFileSync(solutionPath, solText, { encoding: 'utf8' });
         });
 
         // Add the ItemGroup/ProjectReference to each matching cordova project :
@@ -285,7 +285,7 @@ jsprojManager.prototype = {
 
         // There may be multiple solutions (for different VS versions) - process them all
         getSolutionPaths(this.projectFolder).forEach(function (solutionPath) {
-            var solText = fs.readFileSync(solutionPath, {encoding: 'utf8'});
+            var solText = fs.readFileSync(solutionPath, { encoding: 'utf8' });
 
             // To be safe (to handle subtle changes in formatting, for example), use a RegExp to find and remove
             // preInsertText and postInsertText
@@ -298,7 +298,7 @@ jsprojManager.prototype = {
                 return '';
             });
 
-            fs.writeFileSync(solutionPath, solText, {encoding: 'utf8'});
+            fs.writeFileSync(solutionPath, solText, { encoding: 'utf8' });
         });
 
         this._getMatchingProjects(targetConditions).forEach(function (project) {
@@ -460,7 +460,7 @@ function proj (location) {
 
 proj.prototype = {
     write: function () {
-        fs.writeFileSync(this.location, this.xml.write({indent: 4}), 'utf-8');
+        fs.writeFileSync(this.location, this.xml.write({ indent: 4 }), 'utf-8');
     },
 
     appendToRoot: function (element) {

--- a/template/cordova/lib/prepare.js
+++ b/template/cordova/lib/prepare.js
@@ -118,7 +118,7 @@ module.exports.updateBuildConfig = function (buildConfig) {
         path.join(projectRoot, 'CordovaAppRelease.projitems') :
         path.join(projectRoot, 'CordovaAppDebug.projitems');
 
-    fs.writeFileSync(buildConfigFileName, TEMPLATE + buildConfigXML.write({indent: 2, xml_declaration: false}), 'utf-8');
+    fs.writeFileSync(buildConfigFileName, TEMPLATE + buildConfigXML.write({ indent: 2, xml_declaration: false }), 'utf-8');
 };
 
 function updateManifestFile (config, manifestPath) {
@@ -307,30 +307,30 @@ function applyNavigationWhitelist (config, manifest) {
 
 // Platform default images
 var PLATFORM_IMAGES = [
-    {dest: 'Square150x150Logo.scale-100', width: 150, height: 150},
-    {dest: 'Square30x30Logo.scale-100', width: 30, height: 30},
-    {dest: 'StoreLogo.scale-100', width: 50, height: 50},
-    {dest: 'SplashScreen.scale-100', width: 620, height: 300, targetProject: TARGET_PROJECT_10},
-    {dest: 'SplashScreen.scale-125', width: 775, height: 375, targetProject: TARGET_PROJECT_10},
-    {dest: 'SplashScreen.scale-140', width: 868, height: 420, targetProject: TARGET_PROJECT_81},
-    {dest: 'SplashScreen.scale-150', width: 930, height: 450, targetProject: TARGET_PROJECT_10},
-    {dest: 'SplashScreen.scale-180', width: 1116, height: 540, targetProject: TARGET_PROJECT_81},
-    {dest: 'SplashScreen.scale-200', width: 1240, height: 600, targetProject: TARGET_PROJECT_10},
-    {dest: 'SplashScreen.scale-400', width: 2480, height: 1200, targetProject: TARGET_PROJECT_10},
+    { dest: 'Square150x150Logo.scale-100', width: 150, height: 150 },
+    { dest: 'Square30x30Logo.scale-100', width: 30, height: 30 },
+    { dest: 'StoreLogo.scale-100', width: 50, height: 50 },
+    { dest: 'SplashScreen.scale-100', width: 620, height: 300, targetProject: TARGET_PROJECT_10 },
+    { dest: 'SplashScreen.scale-125', width: 775, height: 375, targetProject: TARGET_PROJECT_10 },
+    { dest: 'SplashScreen.scale-140', width: 868, height: 420, targetProject: TARGET_PROJECT_81 },
+    { dest: 'SplashScreen.scale-150', width: 930, height: 450, targetProject: TARGET_PROJECT_10 },
+    { dest: 'SplashScreen.scale-180', width: 1116, height: 540, targetProject: TARGET_PROJECT_81 },
+    { dest: 'SplashScreen.scale-200', width: 1240, height: 600, targetProject: TARGET_PROJECT_10 },
+    { dest: 'SplashScreen.scale-400', width: 2480, height: 1200, targetProject: TARGET_PROJECT_10 },
     // scaled images are specified here for backward compatibility only so we can find them by size
-    {dest: 'StoreLogo.scale-240', width: 120, height: 120},
-    {dest: 'Square44x44Logo.scale-100', width: 44, height: 44},
-    {dest: 'Square44x44Logo.scale-240', width: 106, height: 106},
-    {dest: 'Square70x70Logo.scale-100', width: 70, height: 70},
-    {dest: 'Square71x71Logo.scale-100', width: 71, height: 71},
-    {dest: 'Square71x71Logo.scale-240', width: 170, height: 170},
-    {dest: 'Square150x150Logo.scale-240', width: 360, height: 360},
-    {dest: 'Square310x310Logo.scale-100', width: 310, height: 310},
-    {dest: 'Wide310x150Logo.scale-100', width: 310, height: 150},
-    {dest: 'Wide310x150Logo.scale-240', width: 744, height: 360},
-    {dest: 'SplashScreenPhone.scale-100', width: 480, height: 800, targetProject: TARGET_PROJECT_WP81},
-    {dest: 'SplashScreenPhone.scale-140', width: 672, height: 1120, targetProject: TARGET_PROJECT_WP81},
-    {dest: 'SplashScreenPhone.scale-240', width: 1152, height: 1920, targetProject: TARGET_PROJECT_WP81}
+    { dest: 'StoreLogo.scale-240', width: 120, height: 120 },
+    { dest: 'Square44x44Logo.scale-100', width: 44, height: 44 },
+    { dest: 'Square44x44Logo.scale-240', width: 106, height: 106 },
+    { dest: 'Square70x70Logo.scale-100', width: 70, height: 70 },
+    { dest: 'Square71x71Logo.scale-100', width: 71, height: 71 },
+    { dest: 'Square71x71Logo.scale-240', width: 170, height: 170 },
+    { dest: 'Square150x150Logo.scale-240', width: 360, height: 360 },
+    { dest: 'Square310x310Logo.scale-100', width: 310, height: 310 },
+    { dest: 'Wide310x150Logo.scale-100', width: 310, height: 150 },
+    { dest: 'Wide310x150Logo.scale-240', width: 744, height: 360 },
+    { dest: 'SplashScreenPhone.scale-100', width: 480, height: 800, targetProject: TARGET_PROJECT_WP81 },
+    { dest: 'SplashScreenPhone.scale-140', width: 672, height: 1120, targetProject: TARGET_PROJECT_WP81 },
+    { dest: 'SplashScreenPhone.scale-240', width: 1152, height: 1920, targetProject: TARGET_PROJECT_WP81 }
 ];
 
 function findPlatformImage (width, height) {

--- a/template/cordova/lib/run.js
+++ b/template/cordova/lib/run.js
@@ -45,7 +45,7 @@ module.exports.run = function (options) {
         'win': Boolean,
         'appx': String,
         'win10tools': Boolean
-    }, {'r': '--release'}, options.argv, 0);
+    }, { 'r': '--release' }, options.argv, 0);
 
     // Validate args
     if (options.debug && options.release) {
@@ -131,7 +131,7 @@ function ranWithElevatedPermissions () {
     try {
         // Check if ran from admin prompt and fail quickly if CLI has administrative permissions
         // http://stackoverflow.com/a/11995662/64949
-        execSync('net session', {'stdio': 'ignore'});
+        execSync('net session', { 'stdio': 'ignore' });
         return true;
     } catch (e) {
         return false;

--- a/template/cordova/lib/utils.js
+++ b/template/cordova/lib/utils.js
@@ -30,7 +30,7 @@ module.exports.getAppStoreUtils = function () {
     if (!fs.existsSync(appStoreUtils)) {
         return Q.reject('Can\'t unblock AppStoreUtils script');
     }
-    return spawn('powershell', ['Unblock-File', module.exports.quote(appStoreUtils)], {stdio: 'ignore'})
+    return spawn('powershell', ['Unblock-File', module.exports.quote(appStoreUtils)], { stdio: 'ignore' })
         .thenResolve(appStoreUtils);
 };
 

--- a/template/cordova/prebuild.js
+++ b/template/cordova/prebuild.js
@@ -50,7 +50,9 @@ module.exports = function patch (platform) {
     // 1. Find start page path in appxmanifest
     var AppxManifest = require('./lib/AppxManifest');
     var appxmanifest = AppxManifest.get(path.join(__dirname, '..', appxmanifestMap[platform]));
-    var startPage = url.parse(appxmanifest.getApplication().getStartPage());
+
+    // @todo Use 'url.URL' constructor instead
+    var startPage = url.parse(appxmanifest.getApplication().getStartPage()); // eslint-disable-line 
 
     if (startPage.protocol && startPage.protocol.indexOf('http') === 0) {
         console.warn('Warning: Can\'t modify external content.src. You should update your server-side pages to reference WinJS directly in HTML.');


### PR DESCRIPTION
### Platforms affected
windows

### What does this PR do?
This PR contains final preparations for the Cordova 9 release goals. 

See [Cordova 9 Release Plan](https://github.com/apache/cordova/issues/10).
 
- Bumped `cordova-common@^3.1.0`
- Bumped ESLint dependencies with correction
  - `eslint@^5.12.0`
  - `eslint-config-semistandard@^13.0.0`
  - `eslint-config-standard@^12.0.0`
  - `eslint-plugin-import@^2.14.0`
  - `eslint-plugin-node@^8.0.1`
  - `eslint-plugin-promise@^4.0.1`
  - `eslint-plugin-standard@^4.0.0`
- Bumped Dev Dependencies & Pinned Jasmine at 3.1.0
  - `jasmine@3.1.0`
  - `rewire@^4.0.1`
- Updated Dependencies
  - `nopt@^4.0.1`
- Replace istanbul dependency with `nyc@^13.1.0`

### What testing has been done on this change?
- `npm run eslint`
- `npm run cover` (unit testing)
- [Travis CI](https://travis-ci.org/erisu/cordova-windows/builds/477177036)
- [AppVeyor](https://ci.appveyor.com/project/erisu/cordova-windows/builds/21482766)
- Platform Add & Prepare
  ```
  $ npx cordova@nightly create androidTest com.foobar.androidTest
  $ npx cordova@nightly platform add github:erisu/cordova-windows\#cordova9-prep
  $ npx cordova@nightly prepare windows
  ```