### PR TITLE
change temporary directories for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage/*
 testcreate*
 coverage/
 .nyc_output/
+temp/*

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
+    "fs-extra": "^7.0.1",
     "jasmine": "3.1.0",
     "nyc": "^13.1.0",
     "rewire": "^4.0.1"

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -17,7 +17,7 @@
     under the License.
 */
 var shell = require('shelljs');
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 
 var FIXTURES = path.join(__dirname, '../unit/fixtures');
@@ -30,8 +30,10 @@ var PluginInfo = require('cordova-common').PluginInfo;
 
 describe('Cordova create and build', function () {
 
+    var templateDir = path.join(__dirname, '../../template');
     var projectFolder = 'testcreate 応用';
-    var buildDirectory = path.join(__dirname, '../..');
+    var workingDirectory = path.join(__dirname, '../../temp');
+    var buildDirectory = path.join(workingDirectory, 'platforms');
     var appPackagesFolder = path.join(buildDirectory, projectFolder, 'AppPackages');
     var buildScriptPath = '"' + path.join(buildDirectory, projectFolder, 'cordova', 'build') + '"';
     var prepareScriptPath = '"' + path.join(buildDirectory, projectFolder, 'cordova', 'prepare') + '"';
@@ -61,17 +63,19 @@ describe('Cordova create and build', function () {
     }
 
     beforeEach(function () {
-        shell.exec(path.join('bin', 'create') + ' "' + projectFolder + '" com.test.app 応用', { silent: silent });
+        fs.ensureDirSync(buildDirectory);
+        fs.copySync(path.join(templateDir, 'www'), path.join(workingDirectory, 'www'));
+        fs.copySync(path.join(templateDir, 'config.xml'), path.join(workingDirectory, 'config.xml'));
+        shell.exec(path.join('bin', 'create') + ' "' + path.join(buildDirectory, projectFolder) + '" com.test.app 応用', { silent: silent });
         shell.exec(prepareScriptPath + '', { silent: silent });
     });
 
     afterEach(function () {
-        shell.cd(buildDirectory);
-        shell.rm('-rf', projectFolder);
+        fs.removeSync(workingDirectory);
     });
 
     it('spec.1 should create new project', function () {
-        expect(fs.existsSync(projectFolder)).toBe(true);
+        expect(fs.existsSync(path.join(buildDirectory, projectFolder))).toBe(true);
     });
 
     // default
@@ -159,9 +163,9 @@ describe('Cordova create and build', function () {
 
         extensionsPluginInfo = new PluginInfo(extensionsPlugin);
         api = new Api();
-        api.root = projectFolder;
-        api.locations.root = projectFolder;
-        api.locations.www = path.join(projectFolder, 'www');
+        api.root = path.join(buildDirectory, projectFolder);
+        api.locations.root = path.join(buildDirectory, projectFolder);
+        api.locations.www = path.join(buildDirectory, projectFolder, 'www');
 
         var fail = jasmine.createSpy('fail')
             .and.callFake(function (err) {
@@ -185,9 +189,9 @@ describe('Cordova create and build', function () {
 
         extensionsPluginInfo = new PluginInfo(extensionsPlugin);
         api = new Api();
-        api.root = projectFolder;
-        api.locations.root = projectFolder;
-        api.locations.www = path.join(projectFolder, 'www');
+        api.root = path.join(buildDirectory, projectFolder);
+        api.locations.root = path.join(buildDirectory, projectFolder);
+        api.locations.www = path.join(buildDirectory, projectFolder, 'www');
 
         var fail = jasmine.createSpy('fail')
             .and.callFake(function (err) {

--- a/template/cordova/prepare
+++ b/template/cordova/prepare
@@ -44,7 +44,7 @@ opts.noPrepare = true;
 
 require('./lib/loggingHelper').adjustLoggerLevel(opts);
 
-var projectRoot = path.join(__dirname, '..');
+var projectRoot = path.join(__dirname, '../../..');
 var project = {
     root: projectRoot,
     projectConfig: new ConfigParser(path.join(projectRoot, 'config.xml')),


### PR DESCRIPTION
### Platforms affected
windows

### Motivation and Context
Fixing following spec error

```
C:\Users\knaito\Documents\work\cordova-develop\cordova-windows\testcreate 応用\cordova\node_modules\fs-extra\lib\copy-sync\copy-sync.js:185   
    throw new Error('Source and destination must not be the same.')                                                                         

Error: Source and destination must not be the same.
``` 

### Description

The above error happens because `FileUpdater` in `cordova-common` checks args strictly. (The older `cordova-common`, does not check args strictly)

Therefore this PR updates tests' directory structure in order to statisfy the correct args.
Detecting `config.xml` in `cordova/prepare` is also improved accroding to the new tests' directory structure.

### Testing
```
npm run test
```

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
