### PR TITLE
Support latest Visual Studio 2017 (15.9.x)

### DIFF
--- a/template/cordova/lib/MSBuildTools.js
+++ b/template/cordova/lib/MSBuildTools.js
@@ -113,7 +113,7 @@ module.exports.findAllAvailableVersions = function () {
 function findAllAvailableVersionsFallBack () {
     // console.log('findAllAvailableVersionsFALLBACK');
 
-    var versions = ['15.5', '15.0', '14.0', '12.0', '4.0'];
+    var versions = ['15.9', '15.5', '15.0', '14.0', '12.0', '4.0'];
     events.emit('verbose', 'Searching for available MSBuild versions...');
 
     return Q.all(versions.map(checkMSBuildVersion)).then(function (unprocessedResults) {


### PR DESCRIPTION
Latest Visual Studio 2017 comes with MSBuild 15.9:

```
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin
λ msbuild -version -nologo
15.9.21.664
```

As we have a strangely hardcoded list of support MSBuild versions, this needs to be added to work.