### PR TITLE
Conditionally skip the _one_ broken test for VS 2017 instead of allowing the whole suite to fail

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,10 +31,6 @@ environment:
     - nodejs_version: "6"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-matrix:
-  allow_failures:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -213,7 +213,16 @@ describe('Cordova create and build', function () {
 
     // --release --bundle
 
-    // here be 6a
+    it('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
+        // FIXME Fails for VS 2017 on AppVeyor
+        if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017') {
+            pending('This test is broken for VS 2017 on AppVeyor');
+        }
+
+        shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', { silent: silent });
+        _expectExist(/.*bundle\.appxupload$/, 3);
+        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_Test', 'CordovaApp.Windows10_1.0.0.0_x64_x86_arm.appxbundle');
+    });
 
     it('spec.6b should generate appxupload and appxbundle for Windows Phone 8.1 project bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --appx=8.1-phone --bundle --archs=\"x64 x86 arm\"', { silent: silent });
@@ -239,12 +248,5 @@ describe('Cordova create and build', function () {
         _expectExist(/.*\.appxupload$/, 2);
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_arm_Test', 'CordovaApp.Phone_1.0.0.0_arm.appx');
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_x86_Test', 'CordovaApp.Phone_1.0.0.0_x86.appx');
-    });
-
-    // this will be move up again when it is fixed for VS 2017 on AppVeyor
-    it('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', { silent: silent });
-        _expectExist(/.*bundle\.appxupload$/, 3);
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_Test', 'CordovaApp.Windows10_1.0.0.0_x64_x86_arm.appxbundle');
     });
 });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The CI tests on AppVeyor using VS 2017 were allowed to fail completely because of _one_ E2E test that is broken under these conditions. This is confusing and could mask any other broken tests.

Example: https://ci.appveyor.com/project/ApacheSoftwareFoundation/cordova-windows/builds/23755792

### Description
<!-- Describe your changes in detail -->
Instead of allowing the whole suite to fail when using VS 2017, we only skip the known-bad tests when VS 2017 on AppVeyor is used.
