### PR TITLE
Fix path to winjs dependency

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -91,7 +91,7 @@ module.exports.create = function (destinationDir, config, options) {
     // Copy base.js into the target project directory
     var destinationDirectory = path.join(projectPath, 'platform_www', 'WinJS', 'js');
     var destBaseJsPath = path.join(destinationDirectory, 'base.js');
-    var srcBaseJsPath = path.join(root, 'node_modules', 'winjs', 'js', 'base.js');
+    var srcBaseJsPath = require.resolve('winjs/js/base');
     recursiveCreateDirectory(destinationDirectory);
     shell.cp('-f', srcBaseJsPath, destBaseJsPath);
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #326


### Description
<!-- Describe your changes in detail -->
Properly resolve the path to our dependency instead of guessing it.


### Testing
<!-- Please describe in detail how you tested your changes. -->
**Manual**:
```sh
$ cordova create cordovaWindows7Test
Creating a new cordova project.
$ cd cordovaWindows7Test
$ cordova platform add ~/code/cordova-windows
Warning: using prerelease platform windows@7.1.0-dev.
Use 'cordova platform add windows@latest' to add the latest published version instead.
Adding windows project...
Creating Cordova Windows Project:
	Path: platforms/windows
	Namespace: io.cordova.hellocordova
	Name: HelloCordova
Windows project created with cordova-windows@7.1.0-dev
Plugin 'cordova-plugin-whitelist' found in config.xml... Migrating it to package.json
Discovered saved plugin "cordova-plugin-whitelist". Adding it to the project
Installing "cordova-plugin-whitelist" for windows
Adding cordova-plugin-whitelist to package.json
```

Unfortunately, a regression test is not easily to be had. The Problem is that, in our E2E tests, `create` copies the `node_modules` folder to where it expects it later when copying the `winjs` file. In a multi-platform project setup via CLI, the layout is different and `node_modules` is not copied in the first place.