### PR TITLE
refactor: split tests into suites for Windows 10 and Windows 8.1 (to be able to disable conditionally)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,10 @@ environment:
 
     - nodejs_version: "6"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      MSBUILDDIR: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\"
+
+    - nodejs_version: "6"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       MSBUILDDIR: "C:\\Program Files (x86)\\MSBuild\\14.0\\bin\\"
 
     - nodejs_version: "6"

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -172,6 +172,15 @@ describe('Cordova create and build', function () {
 
     describe('Windows 8.1', function () {
 
+        if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017') {
+            pending('Windows 8.1 builds are not supported by Visual Studio 2017: https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2017-compatibility-vs#windows-store-and-windows-phone-apps');
+            /*
+                via https://issues.apache.org/jira/browse/CB-13874
+                > Projects for Windows Store 8.1 and 8.0, and Windows Phone 8.1 and 8.0 are not supported in this release. 
+                > To maintain these apps, continue to use Visual Studio 2015
+            */
+        }
+
         it('spec.2d should build 8.1 win project', function () {
             shell.exec(buildScriptPath + ' --appx=8.1-win', { silent: silent });
             _expectExist(/.*Windows.*\.appxupload/);

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -195,7 +195,7 @@ describe('Cordova create and build', function () {
             _expectExist(/.*Phone.*x64.*\.appxupload/);
             _expectExist(/.*Windows.*x64.*\.appxupload/);
         });
-        
+
         it('spec.3c should build project (8.1-win) for particular CPU', function () {
             shell.exec(buildScriptPath + ' --appx=8.1-win --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
             _expectExist(/.*Windows.*x64.*\.appxupload/);

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -80,24 +80,24 @@ describe('Cordova create and build', function () {
 
     describe('Windows 10', function () {
 
-    // default
+        // default
 
-    it('spec.2a should build default (win10) project', function () {
-        shell.exec(buildScriptPath + '', { silent: silent });
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
-    });
+        it('spec.2a should build default (win10) project', function () {
+            shell.exec(buildScriptPath + '', { silent: silent });
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
+        });
 
-    // --appx
+        // --appx
 
-    it('spec.2b should build uap (win10) project', function () {
-        shell.exec(buildScriptPath + ' --appx=uap', { silent: silent });
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
-    });
+        it('spec.2b should build uap (win10) project', function () {
+            shell.exec(buildScriptPath + ' --appx=uap', { silent: silent });
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
+        });
 
-    it('spec.2c should build uwp (win10) project', function () {
-        shell.exec(buildScriptPath + ' --appx=uwp', { silent: silent });
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
-    });
+        it('spec.2c should build uwp (win10) project', function () {
+            shell.exec(buildScriptPath + ' --appx=uwp', { silent: silent });
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
+        });
 
         // --archs
 
@@ -172,97 +172,97 @@ describe('Cordova create and build', function () {
 
     describe('Windows 8.1', function () {
 
-    it('spec.2d should build 8.1 win project', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1-win', { silent: silent });
-        _expectExist(/.*Windows.*\.appxupload/);
-    });
+        it('spec.2d should build 8.1 win project', function () {
+            shell.exec(buildScriptPath + ' --appx=8.1-win', { silent: silent });
+            _expectExist(/.*Windows.*\.appxupload/);
+        });
 
-    it('spec.2e should build 8.1 phone project', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1-phone', { silent: silent });
-        _expectExist(/.*Phone.*\.appxupload/);
-    });
+        it('spec.2e should build 8.1 phone project', function () {
+            shell.exec(buildScriptPath + ' --appx=8.1-phone', { silent: silent });
+            _expectExist(/.*Phone.*\.appxupload/);
+        });
 
-    it('spec.2f should build 8.1 win + phone project', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1', { silent: silent });
-        _expectExist(/.*Windows.*\.appxupload/);
-        _expectExist(/.*Phone.*\.appxupload/);
-    });
+        it('spec.2f should build 8.1 win + phone project', function () {
+            shell.exec(buildScriptPath + ' --appx=8.1', { silent: silent });
+            _expectExist(/.*Windows.*\.appxupload/);
+            _expectExist(/.*Phone.*\.appxupload/);
+        });
 
-    // --archs
+        // --archs
 
-    it('spec.3b should build project (8.1) for particular CPU', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
-        _expectExist(/.*Phone.*x64.*\.appxupload/);
-        _expectExist(/.*Windows.*x64.*\.appxupload/);
-    });
+        it('spec.3b should build project (8.1) for particular CPU', function () {
+            shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
+            _expectExist(/.*Phone.*x64.*\.appxupload/);
+            _expectExist(/.*Windows.*x64.*\.appxupload/);
+        });
+        
+        it('spec.3c should build project (8.1-win) for particular CPU', function () {
+            shell.exec(buildScriptPath + ' --appx=8.1-win --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
+            _expectExist(/.*Windows.*x64.*\.appxupload/);
+        });
 
-    it('spec.3c should build project (8.1-win) for particular CPU', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1-win --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
-        _expectExist(/.*Windows.*x64.*\.appxupload/);
-    });
+        it('spec.3d should build project (8.1-phone) for particular CPU', function () {
+            shell.exec(buildScriptPath + ' --appx=8.1-phone --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
+            _expectExist(/.*Phone.*x64.*\.appxupload/);
+        });
 
-    it('spec.3d should build project (8.1-phone) for particular CPU', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1-phone --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
-        _expectExist(/.*Phone.*x64.*\.appxupload/);
-    });
+        it('spec.4b should build project (8.1) for CPUs separated by whitespaces', function () {
+            shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64 x86 arm anycpu\"', { silent: silent }); /* eslint no-useless-escape : 0 */
+            _expectExist(/.*Phone.*x86.*\.appxupload/);
+            _expectExist(/.*Phone.*x64.*\.appxupload/);
+            _expectExist(/.*Phone.*arm.*\.appxupload/);
+            _expectExist(/.*Phone.*AnyCPU.*\.appxupload/i);
+            _expectExist(/.*Windows.*x64.*\.appxupload/);
+            _expectExist(/.*Windows.*x86.*\.appxupload/);
+            _expectExist(/.*Windows.*arm.*\.appxupload/);
+            _expectExist(/.*Windows.*anycpu.*\.appxupload/i);
+        });
 
-    it('spec.4b should build project (8.1) for CPUs separated by whitespaces', function () {
-        shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64 x86 arm anycpu\"', { silent: silent }); /* eslint no-useless-escape : 0 */
-        _expectExist(/.*Phone.*x86.*\.appxupload/);
-        _expectExist(/.*Phone.*x64.*\.appxupload/);
-        _expectExist(/.*Phone.*arm.*\.appxupload/);
-        _expectExist(/.*Phone.*AnyCPU.*\.appxupload/i);
-        _expectExist(/.*Windows.*x64.*\.appxupload/);
-        _expectExist(/.*Windows.*x86.*\.appxupload/);
-        _expectExist(/.*Windows.*arm.*\.appxupload/);
-        _expectExist(/.*Windows.*anycpu.*\.appxupload/i);
-    });
+        // "InProcessServer extension"
 
-    // "InProcessServer extension"
+        it('spec.5b should build project (8.1) containing plugin with InProcessServer extension', function (done) {
+            var extensionsPluginInfo, api;
 
-    it('spec.5b should build project (8.1) containing plugin with InProcessServer extension', function (done) {
-        var extensionsPluginInfo, api;
+            extensionsPluginInfo = new PluginInfo(extensionsPlugin);
+            api = new Api();
+            api.root = path.join(buildDirectory, projectFolder);
+            api.locations.root = path.join(buildDirectory, projectFolder);
+            api.locations.www = path.join(buildDirectory, projectFolder, 'www');
 
-        extensionsPluginInfo = new PluginInfo(extensionsPlugin);
-        api = new Api();
-        api.root = path.join(buildDirectory, projectFolder);
-        api.locations.root = path.join(buildDirectory, projectFolder);
-        api.locations.www = path.join(buildDirectory, projectFolder, 'www');
+            var fail = jasmine.createSpy('fail')
+                .and.callFake(function (err) {
+                    console.error(err);
+                });
 
-        var fail = jasmine.createSpy('fail')
-            .and.callFake(function (err) {
-                console.error(err);
-            });
+            api.addPlugin(extensionsPluginInfo)
+                .then(function () {
+                    shell.exec(buildScriptPath + ' --appx=8.1', { silent: silent });
+                    _expectExist(/.*Windows.*\.appxupload/);
+                    _expectExist(/.*Phone.*\.appxupload/);
+                })
+                .catch(fail)
+                .finally(function () {
+                    expect(fail).not.toHaveBeenCalled();
+                    done();
+                });
+        });
 
-        api.addPlugin(extensionsPluginInfo)
-            .then(function () {
-                shell.exec(buildScriptPath + ' --appx=8.1', { silent: silent });
-                _expectExist(/.*Windows.*\.appxupload/);
-                _expectExist(/.*Phone.*\.appxupload/);
-            })
-            .catch(fail)
-            .finally(function () {
-                expect(fail).not.toHaveBeenCalled();
-                done();
-            });
-    });
+        // --release --bundle
 
-    // --release --bundle
+        it('spec.6b should generate appxupload and appxbundle for Windows Phone 8.1 project bundle release build', function () {
+            shell.exec(buildScriptPath + ' --release --appx=8.1-phone --bundle --archs=\"x64 x86 arm\"', { silent: silent });
+            _expectExist(/.*bundle\.appxupload$/, 3);
+            _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_Test', 'CordovaApp.Phone_1.0.0.0_x64_x86_arm.appxbundle');
+        });
 
-    it('spec.6b should generate appxupload and appxbundle for Windows Phone 8.1 project bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --appx=8.1-phone --bundle --archs=\"x64 x86 arm\"', { silent: silent });
-        _expectExist(/.*bundle\.appxupload$/, 3);
-        _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_Test', 'CordovaApp.Phone_1.0.0.0_x64_x86_arm.appxbundle');
-    });
+        // --release (non-bundle)
 
-    // --release (non-bundle)
-
-    it('spec.8 for a non-bundle case for Windows Phone 8.1 it should build appx in separate dirs for each architecture', function () {
-        shell.exec(buildScriptPath + ' --release --appx=8.1-phone --phone --archs=\"x86 arm\"', { silent: silent });
-        _expectExist(/.*\.appxupload$/, 2);
-        _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_arm_Test', 'CordovaApp.Phone_1.0.0.0_arm.appx');
-        _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_x86_Test', 'CordovaApp.Phone_1.0.0.0_x86.appx');
-    });
+        it('spec.8 for a non-bundle case for Windows Phone 8.1 it should build appx in separate dirs for each architecture', function () {
+            shell.exec(buildScriptPath + ' --release --appx=8.1-phone --phone --archs=\"x86 arm\"', { silent: silent });
+            _expectExist(/.*\.appxupload$/, 2);
+            _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_arm_Test', 'CordovaApp.Phone_1.0.0.0_arm.appx');
+            _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_x86_Test', 'CordovaApp.Phone_1.0.0.0_x86.appx');
+        });
 
     });
 

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -78,6 +78,8 @@ describe('Cordova create and build', function () {
         expect(fs.existsSync(path.join(buildDirectory, projectFolder))).toBe(true);
     });
 
+    describe('Windows 10', function () {
+
     // default
 
     it('spec.2a should build default (win10) project', function () {
@@ -97,6 +99,79 @@ describe('Cordova create and build', function () {
         _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
     });
 
+        // --archs
+
+        it('spec.3a should build project for particular CPU', function () {
+            shell.exec(buildScriptPath + ' --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x64_debug.appx');
+        });
+
+        it('spec.4a should build project for CPUs separated by whitespaces', function () {
+            shell.exec(buildScriptPath + ' --archs=\"x64 x86 arm anycpu\"', { silent: silent }); /* eslint no-useless-escape : 0 */
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x64_debug.appx');
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x86_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x86_debug.appx');
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_arm_debug_Test', 'CordovaApp.Windows10_1.0.0.0_arm_debug.appx');
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
+        });
+
+        // "InProcessServer extension"
+
+        it('spec.5a should build project containing plugin with InProcessServer extension', function (done) {
+            var extensionsPluginInfo, api;
+
+            extensionsPluginInfo = new PluginInfo(extensionsPlugin);
+            api = new Api();
+            api.root = path.join(buildDirectory, projectFolder);
+            api.locations.root = path.join(buildDirectory, projectFolder);
+            api.locations.www = path.join(buildDirectory, projectFolder, 'www');
+
+            var fail = jasmine.createSpy('fail')
+                .and.callFake(function (err) {
+                    console.error(err);
+                });
+
+            api.addPlugin(extensionsPluginInfo)
+                .then(function () {
+                    shell.exec(buildScriptPath, { silent: silent });
+                    _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
+                })
+                .catch(fail)
+                .finally(function () {
+                    expect(fail).not.toHaveBeenCalled();
+                    done();
+                });
+        });
+
+        // --release --bundle
+
+        it('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
+            // FIXME Fails for VS 2017 on AppVeyor
+            if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017') {
+                pending('This test is broken for VS 2017 on AppVeyor');
+            }
+
+            shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', { silent: silent });
+            _expectExist(/.*bundle\.appxupload$/, 3);
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_Test', 'CordovaApp.Windows10_1.0.0.0_x64_x86_arm.appxbundle');
+        });
+
+        // --release (non-bundle)
+
+        it('spec.7 should generate appxupload for Windows 10 project non-bundle release build', function () {
+            shell.exec(buildScriptPath + ' --release --archs=\"x64 x86 arm\"', { silent: silent });
+            _expectExist(/.*\.appxupload$/, 3);
+            // CB-12416 Should build appx in separate dirs for each architecture
+            // Should contain a subdirectory for each of the architectures
+            // These subdirectories should contain corresponding appx files
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_arm_Test', 'CordovaApp.Windows10_1.0.0.0_arm.appx');
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_Test', 'CordovaApp.Windows10_1.0.0.0_x64.appx');
+            _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x86_Test', 'CordovaApp.Windows10_1.0.0.0_x86.appx');
+        });
+
+    });
+
+    describe('Windows 8.1', function () {
+
     it('spec.2d should build 8.1 win project', function () {
         shell.exec(buildScriptPath + ' --appx=8.1-win', { silent: silent });
         _expectExist(/.*Windows.*\.appxupload/);
@@ -115,11 +190,6 @@ describe('Cordova create and build', function () {
 
     // --archs
 
-    it('spec.3a should build project for particular CPU', function () {
-        shell.exec(buildScriptPath + ' --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x64_debug.appx');
-    });
-
     it('spec.3b should build project (8.1) for particular CPU', function () {
         shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64\"', { silent: silent }); /* eslint no-useless-escape : 0 */
         _expectExist(/.*Phone.*x64.*\.appxupload/);
@@ -136,14 +206,6 @@ describe('Cordova create and build', function () {
         _expectExist(/.*Phone.*x64.*\.appxupload/);
     });
 
-    it('spec.4a should build project for CPUs separated by whitespaces', function () {
-        shell.exec(buildScriptPath + ' --archs=\"x64 x86 arm anycpu\"', { silent: silent }); /* eslint no-useless-escape : 0 */
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x64_debug.appx');
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x86_debug_Test', 'CordovaApp.Windows10_1.0.0.0_x86_debug.appx');
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_arm_debug_Test', 'CordovaApp.Windows10_1.0.0.0_arm_debug.appx');
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
-    });
-
     it('spec.4b should build project (8.1) for CPUs separated by whitespaces', function () {
         shell.exec(buildScriptPath + ' --appx=8.1 --archs=\"x64 x86 arm anycpu\"', { silent: silent }); /* eslint no-useless-escape : 0 */
         _expectExist(/.*Phone.*x86.*\.appxupload/);
@@ -157,32 +219,6 @@ describe('Cordova create and build', function () {
     });
 
     // "InProcessServer extension"
-
-    it('spec.5a should build project containing plugin with InProcessServer extension', function (done) {
-        var extensionsPluginInfo, api;
-
-        extensionsPluginInfo = new PluginInfo(extensionsPlugin);
-        api = new Api();
-        api.root = path.join(buildDirectory, projectFolder);
-        api.locations.root = path.join(buildDirectory, projectFolder);
-        api.locations.www = path.join(buildDirectory, projectFolder, 'www');
-
-        var fail = jasmine.createSpy('fail')
-            .and.callFake(function (err) {
-                console.error(err);
-            });
-
-        api.addPlugin(extensionsPluginInfo)
-            .then(function () {
-                shell.exec(buildScriptPath, { silent: silent });
-                _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
-            })
-            .catch(fail)
-            .finally(function () {
-                expect(fail).not.toHaveBeenCalled();
-                done();
-            });
-    });
 
     it('spec.5b should build project (8.1) containing plugin with InProcessServer extension', function (done) {
         var extensionsPluginInfo, api;
@@ -213,17 +249,6 @@ describe('Cordova create and build', function () {
 
     // --release --bundle
 
-    it('spec.6a should generate appxupload and appxbundle for Windows 10 project bundle release build', function () {
-        // FIXME Fails for VS 2017 on AppVeyor
-        if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017') {
-            pending('This test is broken for VS 2017 on AppVeyor');
-        }
-
-        shell.exec(buildScriptPath + ' --release --bundle --archs=\"x64 x86 arm\"', { silent: silent });
-        _expectExist(/.*bundle\.appxupload$/, 3);
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_Test', 'CordovaApp.Windows10_1.0.0.0_x64_x86_arm.appxbundle');
-    });
-
     it('spec.6b should generate appxupload and appxbundle for Windows Phone 8.1 project bundle release build', function () {
         shell.exec(buildScriptPath + ' --release --appx=8.1-phone --bundle --archs=\"x64 x86 arm\"', { silent: silent });
         _expectExist(/.*bundle\.appxupload$/, 3);
@@ -232,21 +257,13 @@ describe('Cordova create and build', function () {
 
     // --release (non-bundle)
 
-    it('spec.7 should generate appxupload for Windows 10 project non-bundle release build', function () {
-        shell.exec(buildScriptPath + ' --release --archs=\"x64 x86 arm\"', { silent: silent });
-        _expectExist(/.*\.appxupload$/, 3);
-        // CB-12416 Should build appx in separate dirs for each architecture
-        // Should contain a subdirectory for each of the architectures
-        // These subdirectories should contain corresponding appx files
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_arm_Test', 'CordovaApp.Windows10_1.0.0.0_arm.appx');
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x64_Test', 'CordovaApp.Windows10_1.0.0.0_x64.appx');
-        _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_x86_Test', 'CordovaApp.Windows10_1.0.0.0_x86.appx');
-    });
-
     it('spec.8 for a non-bundle case for Windows Phone 8.1 it should build appx in separate dirs for each architecture', function () {
         shell.exec(buildScriptPath + ' --release --appx=8.1-phone --phone --archs=\"x86 arm\"', { silent: silent });
         _expectExist(/.*\.appxupload$/, 2);
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_arm_Test', 'CordovaApp.Phone_1.0.0.0_arm.appx');
         _expectSubdirAndFileExist('CordovaApp.Phone_1.0.0.0_x86_Test', 'CordovaApp.Phone_1.0.0.0_x86.appx');
     });
+
+    });
+
 });

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -173,7 +173,7 @@ describe('Cordova create and build', function () {
     describe('Windows 8.1', function () {
 
         beforeEach(function () {
-            if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017') {
+            if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017' && process.env.MSBUILDDIR != "C:\Program Files (x86)\MSBuild\14.0\bin\") {
                 pending('Windows 8.1 builds are not supported by Visual Studio 2017: https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2017-compatibility-vs#windows-store-and-windows-phone-apps');
                 /*
                     via https://issues.apache.org/jira/browse/CB-13874

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -173,7 +173,7 @@ describe('Cordova create and build', function () {
     describe('Windows 8.1', function () {
 
         beforeEach(function () {
-            if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017' && process.env.MSBUILDDIR != "C:\\Program Files (x86)\\MSBuild\\14.0\\bin\\") {
+            if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017' && process.env.MSBUILDDIR !== 'C:\\Program Files (x86)\\MSBuild\\14.0\\bin\\') {
                 pending('Windows 8.1 builds are not supported by Visual Studio 2017: https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2017-compatibility-vs#windows-store-and-windows-phone-apps');
                 /*
                     via https://issues.apache.org/jira/browse/CB-13874

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -173,7 +173,7 @@ describe('Cordova create and build', function () {
     describe('Windows 8.1', function () {
 
         beforeEach(function () {
-            if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017' && process.env.MSBUILDDIR != "C:\Program Files (x86)\MSBuild\14.0\bin\") {
+            if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017' && process.env.MSBUILDDIR != "C:\\Program Files (x86)\\MSBuild\\14.0\\bin\\") {
                 pending('Windows 8.1 builds are not supported by Visual Studio 2017: https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2017-compatibility-vs#windows-store-and-windows-phone-apps');
                 /*
                     via https://issues.apache.org/jira/browse/CB-13874

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -176,7 +176,7 @@ describe('Cordova create and build', function () {
             pending('Windows 8.1 builds are not supported by Visual Studio 2017: https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2017-compatibility-vs#windows-store-and-windows-phone-apps');
             /*
                 via https://issues.apache.org/jira/browse/CB-13874
-                > Projects for Windows Store 8.1 and 8.0, and Windows Phone 8.1 and 8.0 are not supported in this release. 
+                > Projects for Windows Store 8.1 and 8.0, and Windows Phone 8.1 and 8.0 are not supported in this release.
                 > To maintain these apps, continue to use Visual Studio 2015
             */
         }

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -172,14 +172,16 @@ describe('Cordova create and build', function () {
 
     describe('Windows 8.1', function () {
 
-        if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017') {
-            pending('Windows 8.1 builds are not supported by Visual Studio 2017: https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2017-compatibility-vs#windows-store-and-windows-phone-apps');
-            /*
-                via https://issues.apache.org/jira/browse/CB-13874
-                > Projects for Windows Store 8.1 and 8.0, and Windows Phone 8.1 and 8.0 are not supported in this release.
-                > To maintain these apps, continue to use Visual Studio 2015
-            */
-        }
+        beforeAll(function () {
+            if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017') {
+                pending('Windows 8.1 builds are not supported by Visual Studio 2017: https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2017-compatibility-vs#windows-store-and-windows-phone-apps');
+                /*
+                    via https://issues.apache.org/jira/browse/CB-13874
+                    > Projects for Windows Store 8.1 and 8.0, and Windows Phone 8.1 and 8.0 are not supported in this release.
+                    > To maintain these apps, continue to use Visual Studio 2015
+                */
+            }
+        });
 
         it('spec.2d should build 8.1 win project', function () {
             shell.exec(buildScriptPath + ' --appx=8.1-win', { silent: silent });

--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -172,7 +172,7 @@ describe('Cordova create and build', function () {
 
     describe('Windows 8.1', function () {
 
-        beforeAll(function () {
+        beforeEach(function () {
             if (process.env.APPVEYOR_BUILD_WORKER_IMAGE === 'Visual Studio 2017') {
                 pending('Windows 8.1 builds are not supported by Visual Studio 2017: https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2017-compatibility-vs#windows-store-and-windows-phone-apps');
                 /*


### PR DESCRIPTION
This PR splits the tests into two blocks, one for Windows 10 and one for Windows 8.1. The 8.1 block has a `beforeEach` that calls `pending` for each test if they run on the VS17 image (and `MSBUILDDIR` is not manually overridden to use MSBuildTools 14 [from VS15]).

Also adds another environment where `MSBUILDDIR` is explicitly set to 15 to detect regressions when the system image changes.

closes #334