### PR TITLE
Dependency updates July 2019

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "fs-extra": "^8.1.0",
     "jasmine": "3.1.0",
-    "nyc": "^13.1.0",
+    "nyc": "^14.1.1",
     "rewire": "^4.0.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint": "eslint bin && eslint template && eslint spec"
   },
   "dependencies": {
-    "cordova-common": "^3.1.0",
+    "cordova-common": "^3.2.0",
     "elementtree": "^0.1.7",
     "node-uuid": "^1.4.8",
     "nopt": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "fs-extra": "^7.0.1",
+    "fs-extra": "^8.1.0",
     "jasmine": "3.1.0",
     "nyc": "^13.1.0",
     "rewire": "^4.0.1"


### PR DESCRIPTION
- cordova-common@^3.2.0 update in dependencies - to ensure that the recent cordova-common update, with the recent fs-extra@8 update, will be installed even when the user would upgrade from cordova-windows@7.0.0 using npm
- fs-extra@8 update in devDependencies
- nyc@14 update in devDependencies - resolves a non-production npm audit issue

AppVeyor CI build is green for these changes on my fork.

I would normally have proposed these changes in separate PRs, don’t have so much time to do this right now. If approved, I think a merge commit should be used to merge these changes into `master`.

I hope we can get these changes reviewed, approved, and merged before we make the cordova-windows@7.1.0 release.