### PR TITLE
Spec cleanup and fixes

### DIFF
--- a/spec/e2e/endtoend.spec.js
+++ b/spec/e2e/endtoend.spec.js
@@ -116,7 +116,7 @@ describe('Cordova create and build', function () {
 
         // "InProcessServer extension"
 
-        it('spec.5a should build project containing plugin with InProcessServer extension', function (done) {
+        it('spec.5a should build project containing plugin with InProcessServer extension', function () {
             var extensionsPluginInfo, api;
 
             extensionsPluginInfo = new PluginInfo(extensionsPlugin);
@@ -125,20 +125,10 @@ describe('Cordova create and build', function () {
             api.locations.root = path.join(buildDirectory, projectFolder);
             api.locations.www = path.join(buildDirectory, projectFolder, 'www');
 
-            var fail = jasmine.createSpy('fail')
-                .and.callFake(function (err) {
-                    console.error(err);
-                });
-
-            api.addPlugin(extensionsPluginInfo)
+            return api.addPlugin(extensionsPluginInfo)
                 .then(function () {
                     shell.exec(buildScriptPath, { silent: silent });
                     _expectSubdirAndFileExist('CordovaApp.Windows10_1.0.0.0_anycpu_debug_Test', 'CordovaApp.Windows10_1.0.0.0_anycpu_debug.appx');
-                })
-                .catch(fail)
-                .finally(function () {
-                    expect(fail).not.toHaveBeenCalled();
-                    done();
                 });
         });
 
@@ -231,7 +221,7 @@ describe('Cordova create and build', function () {
 
         // "InProcessServer extension"
 
-        it('spec.5b should build project (8.1) containing plugin with InProcessServer extension', function (done) {
+        it('spec.5b should build project (8.1) containing plugin with InProcessServer extension', function () {
             var extensionsPluginInfo, api;
 
             extensionsPluginInfo = new PluginInfo(extensionsPlugin);
@@ -240,21 +230,11 @@ describe('Cordova create and build', function () {
             api.locations.root = path.join(buildDirectory, projectFolder);
             api.locations.www = path.join(buildDirectory, projectFolder, 'www');
 
-            var fail = jasmine.createSpy('fail')
-                .and.callFake(function (err) {
-                    console.error(err);
-                });
-
-            api.addPlugin(extensionsPluginInfo)
+            return api.addPlugin(extensionsPluginInfo)
                 .then(function () {
                     shell.exec(buildScriptPath + ' --appx=8.1', { silent: silent });
                     _expectExist(/.*Windows.*\.appxupload/);
                     _expectExist(/.*Phone.*\.appxupload/);
-                })
-                .catch(fail)
-                .finally(function () {
-                    expect(fail).not.toHaveBeenCalled();
-                    done();
                 });
         });
 

--- a/spec/unit/ConfigChanges.spec.js
+++ b/spec/unit/ConfigChanges.spec.js
@@ -119,13 +119,8 @@ describe('Capabilities within package.windows.appxmanifest', function () {
         return appxmanifest.getCapabilities();
     }
 
-    var fail = jasmine.createSpy('fail')
-        .and.callFake(function (err) {
-            console.error(err);
-        });
-
-    it('should be removed using overriden PlatformMunger', function (done) {
-        api.addPlugin(dummyPluginInfo)
+    it('should be removed using overriden PlatformMunger', function () {
+        return api.addPlugin(dummyPluginInfo)
             .then(function () {
                 //  There is the one default capability in manifest with 'internetClient' name
                 expect(getManifestCapabilities(windowsManifest).length).toBe(getPluginCapabilities(dummyPluginInfo).length + 1);
@@ -133,16 +128,11 @@ describe('Capabilities within package.windows.appxmanifest', function () {
             })
             .then(function () {
                 expect(getManifestCapabilities(windowsManifest).length).toBe(1);
-            })
-            .catch(fail)
-            .finally(function () {
-                expect(fail).not.toHaveBeenCalled();
-                done();
             });
     });
 
-    it('should be added with uap prefixes when install plugin', function (done) {
-        api.addPlugin(dummyPluginInfo)
+    it('should be added with uap prefixes when install plugin', function () {
+        return api.addPlugin(dummyPluginInfo)
             .then(function () {
                 //  There is the one default capability in manifest with 'internetClient' name
                 var manifestCapabilities = getManifestCapabilities(windowsManifest10);
@@ -158,15 +148,10 @@ describe('Capabilities within package.windows.appxmanifest', function () {
             })
             .then(function () {
                 expect(getManifestCapabilities(windowsManifest10).length).toBe(1);
-            })
-            .catch(fail)
-            .finally(function () {
-                expect(fail).not.toHaveBeenCalled();
-                done();
             });
     });
 
-    it('should be added as DeviceCapabilities when install plugin', function (done) {
+    it('should be added as DeviceCapabilities when install plugin', function () {
         function isDeviceCapability (capability) {
             return capability.type === 'DeviceCapability';
         }
@@ -187,7 +172,7 @@ describe('Capabilities within package.windows.appxmanifest', function () {
             expect(manifestCapabilities.length).toBe(1);
         }
 
-        api.addPlugin(dummyPluginInfo)
+        return api.addPlugin(dummyPluginInfo)
             .then(function () {
                 checkCapabilitiesAfterInstall(windowsManifest);
                 checkCapabilitiesAfterInstall(windowsManifest10);
@@ -196,11 +181,6 @@ describe('Capabilities within package.windows.appxmanifest', function () {
             .then(function () {
                 checkCapabilitiesAfterRemove(windowsManifest);
                 checkCapabilitiesAfterRemove(windowsManifest10);
-            })
-            .catch(fail)
-            .finally(function () {
-                expect(fail).not.toHaveBeenCalled();
-                done();
             });
     });
 });

--- a/spec/unit/MSBuildTools.spec.js
+++ b/spec/unit/MSBuildTools.spec.js
@@ -102,7 +102,7 @@ describe('checkMSBuildVersion method', function () {
             'MSBuildToolsPath\tREG_SZ\t' + fakeToolsPath(version) + '\r\n\r\n')
         );
 
-        checkMSBuildVersion(version).then(function (actual) {
+        return checkMSBuildVersion(version).then(function (actual) {
             expect(actual.version).toBe(version);
             expect(actual.path).toBe(fakeToolsPath(version));
         });
@@ -111,7 +111,7 @@ describe('checkMSBuildVersion method', function () {
     it('spec.7 should return null if no tools found for version', function () {
         spawnSpy.and.returnValue(Q.resolve('ERROR: The system was unable to find the specified registry key or value.'));
 
-        checkMSBuildVersion('14.0').then(function (actual) {
+        return checkMSBuildVersion('14.0').then(function (actual) {
             expect(actual).not.toBeDefined();
         });
     });
@@ -119,7 +119,7 @@ describe('checkMSBuildVersion method', function () {
     it('spec.8 should return null on internal error', function () {
         spawnSpy.and.returnValue(Q.reject());
 
-        checkMSBuildVersion('14.0').then(function (actual) {
+        return checkMSBuildVersion('14.0').then(function (actual) {
             expect(actual).not.toBeDefined();
         });
     });

--- a/spec/unit/build.spec.js
+++ b/spec/unit/build.spec.js
@@ -108,21 +108,17 @@ describe('run method', function () {
         build.__set__('ConfigParser', configParserOriginal);
     });
 
-    it('spec.1 should reject if not launched from project directory', function (done) {
-        var rejectSpy = jasmine.createSpy();
+    it('spec.1 should reject if not launched from project directory', function () {
         var buildSpy = jasmine.createSpy();
 
         // utils.isCordovaProject is a spy, so we can call andReturn directly on it
         utils.isCordovaProject.and.returnValue(false);
         createFindAllAvailableVersionsMock([{ version: '14.0', buildProject: buildSpy, path: testPath }]);
 
-        build.run([ 'node', buildPath, '--release', '--debug' ])
-            .fail(rejectSpy)
-            .finally(function () {
-                expect(rejectSpy).toHaveBeenCalled();
-                expect(buildSpy).not.toHaveBeenCalled();
-                done();
-            });
+        return build.run([ 'node', buildPath, '--release', '--debug' ]).then(
+            () => fail('Expected promise to be rejected'),
+            () => expect(buildSpy).not.toHaveBeenCalled()
+        );
     });
 
     it('spec.2 should throw if both debug and release args specified', function () {
@@ -145,12 +141,12 @@ describe('run method', function () {
         }).toThrow();
     });
 
-    it('should respect build configuration from \'buildConfig\' option', function (done) {
+    it('should respect build configuration from \'buildConfig\' option', function () {
 
         createFindAllAvailableVersionsMock([{ version: '14.0', buildProject: jasmine.createSpy(), path: testPath }]);
         var buildConfigPath = path.resolve(__dirname, 'fixtures/fakeBuildConfig.json');
 
-        build.run({ buildConfig: buildConfigPath })
+        return build.run({ buildConfig: buildConfigPath })
             .finally(function () {
                 expect(prepare.updateBuildConfig).toHaveBeenCalled();
                 var buildOpts = prepare.updateBuildConfig.calls.argsFor(0)[0];
@@ -163,56 +159,49 @@ describe('run method', function () {
                     expect(buildOpts[key]).toBeDefined();
                     expect(buildOpts[key]).toEqual(buildConfig[key]);
                 });
-                done();
-            }).fail(function err (errMsg) {
-                expect(errMsg).toBeUndefined();
-                done();
             });
     }, 20000);
 
-    it('spec.4 should call buildProject of MSBuildTools with buildType = "release" if called with --release argument', function (done) {
+    it('spec.4 should call buildProject of MSBuildTools with buildType = "release" if called with --release argument', function () {
         var buildSpy = jasmine.createSpy().and.callFake(function (solutionFile, buildType, buildArch) {
             expect(buildType).toBe('release');
         });
 
         createFindAllAvailableVersionsMock([{ version: '14.0', buildProject: buildSpy, path: testPath }]);
 
-        build.run({ release: true })
+        return build.run({ release: true })
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec.5 should call buildProject of MSBuildTools with buildType = "debug" if called without arguments', function (done) {
+    it('spec.5 should call buildProject of MSBuildTools with buildType = "debug" if called without arguments', function () {
         var buildSpy = jasmine.createSpy().and.callFake(function (solutionFile, buildType, buildArch) {
             expect(buildType).toBe('debug');
         });
 
         createFindAllAvailableVersionsMock([{ version: '14.0', buildProject: buildSpy, path: testPath }]);
 
-        build.run([ 'node', buildPath ])
+        return build.run([ 'node', buildPath ])
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec.6 should call buildProject of MSBuildTools with buildArch = "arm" if called with --archs="arm" argument', function (done) {
+    it('spec.6 should call buildProject of MSBuildTools with buildArch = "arm" if called with --archs="arm" argument', function () {
         var buildSpy = jasmine.createSpy().and.callFake(function (solutionFile, buildType, buildArch) {
             expect(buildArch).toBe('arm');
         });
 
         createFindAllAvailableVersionsMock([{ version: '14.0', buildProject: buildSpy, path: testPath }]);
 
-        build.run({ archs: 'arm' })
+        return build.run({ archs: 'arm' })
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec.7 should call buildProject of MSBuildTools once for all architectures if called with --archs="arm x86 x64 anycpu" argument', function (done) {
+    it('spec.7 should call buildProject of MSBuildTools once for all architectures if called with --archs="arm x86 x64 anycpu" argument', function () {
         var armBuild = jasmine.createSpy();
         var x86Build = jasmine.createSpy();
         var x64Build = jasmine.createSpy();
@@ -244,100 +233,85 @@ describe('run method', function () {
                 }
             }]);
 
-        build.run({ archs: 'arm x86 x64 anycpu', argv: ['--phone'] })
+        return build.run({ archs: 'arm x86 x64 anycpu', argv: ['--phone'] })
             .finally(function () {
                 expect(armBuild).toHaveBeenCalled();
                 expect(x86Build).toHaveBeenCalled();
                 expect(x64Build).toHaveBeenCalled();
                 expect(anyCpuBuild).toHaveBeenCalled();
-                done();
             });
     });
 
-    xit('spec.8 should fail buildProject if built with MSBuildTools version 4.0', function (done) {
+    xit('spec.8 should fail buildProject if built with MSBuildTools version 4.0', function () {
         var buildSpy = jasmine.createSpy();
-        var errorSpy = jasmine.createSpy();
 
         createFindAllAvailableVersionsMock([{ version: '4.0', buildProject: buildSpy, path: testPath }]);
         createConfigParserMock('8.0');
 
-        build.run({ argv: ['--win'] })
-            .fail(function (error) {
-                errorSpy();
+        return build.run({ argv: ['--win'] }).then(
+            () => fail('Expected promise to be rejected'),
+            error => {
                 expect(error).toBeDefined();
-            })
-            .finally(function () {
-                expect(errorSpy).toHaveBeenCalled();
                 expect(buildSpy).not.toHaveBeenCalled();
-                done();
-            });
+            }
+        );
     });
 
-    it('spec.9 should call buildProject of MSBuildTools if built for windows 8.1', function (done) {
+    it('spec.9 should call buildProject of MSBuildTools if built for windows 8.1', function () {
         var buildSpy = jasmine.createSpy();
 
         createFindAllAvailableVersionsMock([{ version: '14.0', buildProject: buildSpy, path: testPath }]);
         createConfigParserMock('8.1');
 
-        build.run({ argv: ['--win'] })
+        return build.run({ argv: ['--win'] })
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
-                done();
             });
     });
 
-    xit('spec.10 should throw an error if windows-target-version has unsupported value', function (done) {
+    xit('spec.10 should throw an error if windows-target-version has unsupported value', function () {
         var buildSpy = jasmine.createSpy();
-        var errorSpy = jasmine.createSpy();
 
         createFindAvailableVersionMock('14.0', testPath, buildSpy);
         createConfigParserMock('unsupported value here');
 
-        build.run({ argv: ['--win'] })
-            .fail(function (error) {
-                errorSpy();
+        return build.run({ argv: ['--win'] }).then(
+            () => fail('Expected promise to be rejected'),
+            error => {
                 expect(error).toBeDefined();
-            })
-            .finally(function () {
-                expect(errorSpy).toHaveBeenCalled();
                 expect(buildSpy).not.toHaveBeenCalled();
-                done();
-            });
+            }
+        );
     });
 
-    it('spec.11 should call buildProject of MSBuildTools if built for windows phone 8.1', function (done) {
+    it('spec.11 should call buildProject of MSBuildTools if built for windows phone 8.1', function () {
         var buildSpy = jasmine.createSpy();
 
         createFindAllAvailableVersionsMock([{ version: '14.0', buildProject: buildSpy, path: testPath }]);
         createConfigParserMock(null, '8.1');
 
-        build.run({ argv: ['--phone'] })
+        return build.run({ argv: ['--phone'] })
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
-                done();
             });
     });
 
-    xit('spec.12 should throw an error if windows-phone-target-version has unsupported value', function (done) {
+    xit('spec.12 should throw an error if windows-phone-target-version has unsupported value', function () {
         var buildSpy = jasmine.createSpy();
-        var errorSpy = jasmine.createSpy();
 
         createFindAvailableVersionMock('14.0', testPath, buildSpy);
         createConfigParserMock(null, 'unsupported value here');
 
-        build.run({ argv: ['--phone'] })
-            .fail(function (error) {
-                errorSpy();
+        return build.run({ argv: ['--phone'] }).then(
+            () => fail('Expected promise to be rejected'),
+            error => {
                 expect(error).toBeDefined();
-            })
-            .finally(function () {
-                expect(errorSpy).toHaveBeenCalled();
                 expect(buildSpy).not.toHaveBeenCalled();
-                done();
-            });
+            }
+        );
     });
 
-    it('spec.13a should be able to override target via --appx parameter', function (done) {
+    it('spec.13a should be able to override target via --appx parameter', function () {
         var buildSpy = jasmine.createSpy().and.callFake(function (solutionFile, buildType, buildArch) {
             // check that we build Windows 10 and not Windows 8.1
             expect(solutionFile.toLowerCase()).toMatch('cordovaapp.windows10.jsproj');
@@ -347,14 +321,13 @@ describe('run method', function () {
         // provision config to target Windows 8.1
         createConfigParserMock('8.1', '8.1');
         // explicitly specify Windows 10 as target
-        build.run({ argv: ['--appx=uap'] })
+        return build.run({ argv: ['--appx=uap'] })
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec.13b should be able to override target via --appx parameter', function (done) {
+    it('spec.13b should be able to override target via --appx parameter', function () {
         var buildSpy = jasmine.createSpy().and.callFake(function (solutionFile, buildType, buildArch) {
             // check that we build Windows 10 and not Windows 8.1
             expect(solutionFile.toLowerCase()).toMatch('cordovaapp.windows10.jsproj');
@@ -364,14 +337,13 @@ describe('run method', function () {
         // provision config to target Windows 8.1
         createConfigParserMock('8.1', '8.1');
         // explicitly specify Windows 10 as target
-        build.run({ argv: ['--appx=uwp'] })
+        return build.run({ argv: ['--appx=uwp'] })
             .finally(function () {
                 expect(buildSpy).toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec.14a should use user-specified msbuild if VSINSTALLDIR variable is set', function (done) {
+    it('spec.14a should use user-specified msbuild if VSINSTALLDIR variable is set', function () {
         var customMSBuildPath = '/some/path';
         var msBuildBinPath = path.join(customMSBuildPath, 'MSBuild/15.0/Bin');
         var customMSBuildVersion = '15.0';
@@ -387,20 +359,17 @@ describe('run method', function () {
                 buildProject: jasmine.createSpy('buildProject').and.returnValue(Q())
             }));
 
-        var fail = jasmine.createSpy('fail');
-
-        build.run({})
-            .fail(fail)
-            .finally(function () {
-                expect(fail).not.toHaveBeenCalled();
+        return build.run({})
+            .then(() => {
                 expect(MSBuildTools.getMSBuildToolsAt).toHaveBeenCalledWith(msBuildBinPath);
+            })
+            .finally(function () {
                 delete process.env.VSINSTALLDIR;
                 process.env.MSBUILDDIR = backupMSBUILDDIR;
-                done();
             });
     });
 
-    it('spec.14b should use user-specified msbuild if MSBUILDDIR variable is set', function (done) {
+    it('spec.14b should use user-specified msbuild if MSBUILDDIR variable is set', function () {
         var msBuildBinPath = path.join('/some/path', 'MSBuild/15.0/Bin');
         var customMSBuildVersion = '15.0';
         process.env.MSBUILDDIR = msBuildBinPath;
@@ -415,50 +384,39 @@ describe('run method', function () {
                 buildProject: jasmine.createSpy('buildProject').and.returnValue(Q())
             }));
 
-        var fail = jasmine.createSpy('fail');
-
-        build.run({})
-            .fail(fail)
-            .finally(function () {
-                expect(fail).not.toHaveBeenCalled();
+        return build.run({})
+            .then(() => {
                 expect(MSBuildTools.getMSBuildToolsAt).toHaveBeenCalledWith(msBuildBinPath);
+            })
+            .finally(function () {
                 delete process.env.MSBUILDDIR;
                 process.env.VSINSTALLDIR = backupVSINSTALLDIR;
-                done();
             });
     });
 
-    it('spec.15a should choose latest version if there are multiple versions available with minor version difference', function (done) {
-        var fail = jasmine.createSpy('fail');
+    it('spec.15a should choose latest version if there are multiple versions available with minor version difference', function () {
         var buildTools14 = { version: '14.0', buildProject: jasmine.createSpy('buildTools14'), path: testPath };
         var buildTools15 = { version: '15.0', buildProject: jasmine.createSpy('buildTools15'), path: testPath };
         var buildTools151 = { version: '15.1', buildProject: jasmine.createSpy('buildTools151'), path: testPath };
 
         createFindAllAvailableVersionsMock([buildTools14, buildTools15, buildTools151]);
         // explicitly specify Windows 10 as target
-        build.run({ argv: ['--appx=uap'] })
-            .fail(fail)
-            .finally(function () {
-                expect(fail).not.toHaveBeenCalled();
+        return build.run({ argv: ['--appx=uap'] })
+            .then(() => {
                 expect(buildTools151.buildProject).toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec.15b should choose latest version if there are multiple versions available with minor version difference', function (done) {
-        var fail = jasmine.createSpy('fail');
+    it('spec.15b should choose latest version if there are multiple versions available with minor version difference', function () {
         var buildTools14 = { version: '14.0', buildProject: jasmine.createSpy('buildTools14'), path: testPath };
         var buildTools15 = { version: '15.0', buildProject: jasmine.createSpy('buildTools15'), path: testPath };
         var buildTools151 = { version: '15.1', buildProject: jasmine.createSpy('buildTools151'), path: testPath };
 
         createFindAllAvailableVersionsMock([buildTools14, buildTools15, buildTools151]);
         // explicitly specify Windows 10 as target
-        build.run({ argv: ['--appx=uwp'] })
-            .fail(fail)
-            .finally(function () {
-                expect(fail).not.toHaveBeenCalled();
+        return build.run({ argv: ['--appx=uap'] })
+            .then(() => {
                 expect(buildTools151.buildProject).toHaveBeenCalled();
-                done();
             });
     });
 });
@@ -502,8 +460,7 @@ describe('buildFlags', function () {
             });
         });
 
-        it('should pass buildFlags directly to MSBuild', function (done) {
-            var fail = jasmine.createSpy('fail');
+        it('should pass buildFlags directly to MSBuild', function () {
             var buildTools = { version: '14.0', buildProject: jasmine.createSpy('buildProject').and.returnValue(Q()), path: testPath };
             var buildOptions = {
                 argv: ['--buildFlag', 'foo=bar']
@@ -511,15 +468,11 @@ describe('buildFlags', function () {
 
             createFindAllAvailableVersionsMock([buildTools]);
 
-            build.run(buildOptions)
-                .fail(fail)
-                .finally(function () {
-                    expect(fail).not.toHaveBeenCalled();
+            return build.run(buildOptions)
+                .then(() => {
                     // CB-12416 AppxBundle=Never is present because we are not building a bundle
                     expect(buildTools.buildProject).toHaveBeenCalledWith(jasmine.any(String),
                         jasmine.any(String), jasmine.any(String), [ 'foo=bar', '/p:AppxBundle=Never' ]);
-
-                    done();
                 });
         });
     });

--- a/spec/unit/check_reqs.spec.js
+++ b/spec/unit/check_reqs.spec.js
@@ -89,75 +89,59 @@ describe('check_reqs module', function () {
             check_reqs.__set__('config', originalconfig);
         });
 
-        it('Test #002 : that should return a promise, fulfilled with an array of Requirements', function (done) {
+        it('Test #002 : that should return a promise, fulfilled with an array of Requirements', function () {
             check_reqs.__set__('requirements', fakeRequirements);
             check_reqs.__set__('checkFns', fakeCheckFns);
             check_reqs.__set__('config', fakeConfig);
             var checkResult = check_reqs.check_all();
             expect(Q.isPromise(checkResult)).toBeTruthy();
-            checkResult.then(function (result) {
+            return checkResult.then(function (result) {
                 expect(result instanceof Array).toBeTruthy();
                 expect(result.length).toBe(3);
                 result.forEach(function (resultItem) {
                     expect(resultItem instanceof Requirement).toBeTruthy();
                     expect(resultItem.installed).toBeTruthy();
                 });
-                done();
             });
         });
 
-        it('Test #003 : that should not reject if one of requirements is not installed', function (done) {
+        it('Test #003 : that should not reject if one of requirements is not installed', function () {
             check_reqs.__set__('requirements', fakeRequirements);
             fakeCheckFns[0] = function () { return Q.reject('Error message'); };
             check_reqs.__set__('checkFns', fakeCheckFns);
             check_reqs.__set__('config', fakeConfig);
 
-            check_reqs.check_all()
+            return check_reqs.check_all()
                 .then(function (requirements) {
                     expect(requirements.length).toBe(3);
                     expect(requirements[0].installed).toBeFalsy();
-                    done();
-                })
-                .catch(function (error) {
-                    expect(error).not.toBeDefined();
-                    done();
                 });
         });
 
-        it('Test #004 : that should reject if one of checks has internal erorrs', function (done) {
+        it('Test #004 : that should reject if one of checks has internal erorrs', function () {
             check_reqs.__set__('requirements', fakeRequirements);
             fakeCheckFns[0] = checkSpy.and.throwError('Fatal error');
             check_reqs.__set__('checkFns', fakeCheckFns);
             check_reqs.__set__('config', fakeConfig);
 
-            check_reqs.check_all()
-                .then(function (requirements) {
-                    expect(requirements).not.toBeDefined();
-                    done();
-                })
-                .catch(function (error) {
-                    expect(error).toMatch('Fatal error');
-                    done();
-                });
+            return check_reqs.check_all().then(
+                () => fail('Expected promise to be rejected'),
+                error => expect(error).toMatch('Fatal error')
+            );
         });
 
-        it('Test #005 : that should not run other requirements checks if `fatal` requirement isn\'t installed', function (done) {
+        it('Test #005 : that should not run other requirements checks if `fatal` requirement isn\'t installed', function () {
             check_reqs.__set__('requirements', fakeRequirements);
             // The second requirement is fatal, so we're setting up second check to fail
             fakeCheckFns[1] = checkSpy.and.returnValue(Q.reject('Error message'));
             check_reqs.__set__('checkFns', fakeCheckFns);
             check_reqs.__set__('config', fakeConfig);
 
-            check_reqs.check_all()
+            return check_reqs.check_all()
                 .then(function (requirements) {
                     expect(requirements.length).toBe(2);
                     expect(requirements[1].isFatal).toBeTruthy();
                     expect(checkSpy.calls.count()).toBe(2);
-                    done();
-                })
-                .catch(function (error) {
-                    expect(error).not.toBeDefined();
-                    done();
                 });
         });
     });

--- a/spec/unit/clean.spec.js
+++ b/spec/unit/clean.spec.js
@@ -32,7 +32,7 @@ describe('Cordova clean command', function () {
         shell.rm('-rf', currentProject);
     });
 
-    it('spec 1. should remove icons when ran inside Cordova project', function (done) {
+    it('spec 1. should remove icons when ran inside Cordova project', function () {
         var config = {
             platform: 'windows',
             root: currentProject,
@@ -43,17 +43,9 @@ describe('Cordova clean command', function () {
             }
         };
 
-        var rejected = jasmine.createSpy().and.callFake(function (err) {
-            // Log error:
-            expect(err).not.toBeDefined();
-        });
-        prepareModule.clean.call(config)
+        return prepareModule.clean.call(config)
             .then(function () {
                 expect(fs.existsSync(iconPath)).toBeFalsy();
-            }, rejected)
-            .finally(function () {
-                expect(rejected).not.toHaveBeenCalled();
-                done();
             });
     });
 });

--- a/spec/unit/deployment.spec.js
+++ b/spec/unit/deployment.spec.js
@@ -98,54 +98,38 @@ describe('Windows 10 deployment interacts with the file system as expected.', fu
         }
     });
 
-    it('Test #002 : enumerateDevices returns a valid set of objects', function (done) {
+    it('Test #002 : enumerateDevices returns a valid set of objects', function () {
         var deploymentTool = deployment.getDeploymentTool('10.0');
-        deploymentTool.enumerateDevices()
+        return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
                 expect(deviceList.length).toBe(3);
                 expect(deviceList[0].name).toBe('Lumia 1520 (RM-940)');
                 expect(deviceList[0].index).toBe(0);
                 expect(deviceList[0].type).toBe('device');
-                done();
-            }).fail(function err (errMsg) {
-                expect(errMsg).toBeUndefined();
-                done();
             });
     });
 
-    it('Test #003 : installAppPackage passes the correct set of parameters', function (done) {
+    it('Test #003 : installAppPackage passes the correct set of parameters', function () {
         var deploymentTool = deployment.getDeploymentTool('10.0');
-        deploymentTool.enumerateDevices()
+        return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
                 deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ false);
-                done();
-            }).fail(function err (errMsg) {
-                expect(errMsg).toBeUndefined();
-                done();
             });
     });
 
-    it('Test #004 : installAppPackage passes the correct set of parameters when updating', function (done) {
+    it('Test #004 : installAppPackage passes the correct set of parameters when updating', function () {
         var deploymentTool = deployment.getDeploymentTool('10.0');
-        deploymentTool.enumerateDevices()
+        return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
                 deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ true);
-                done();
-            }).fail(function err (errMsg) {
-                expect(errMsg).toBeUndefined();
-                done();
             });
     });
 
-    it('Test #005 : uninstallAppPackage passes the correct set of parameters', function (done) {
+    it('Test #005 : uninstallAppPackage passes the correct set of parameters', function () {
         var deploymentTool = deployment.getDeploymentTool('10.0');
-        deploymentTool.enumerateDevices()
+        return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
                 deploymentTool.uninstallAppPackage(TEST_APP_PACKAGE_ID, deviceList[2]);
-                done();
-            }).fail(function err (errMsg) {
-                expect(errMsg).toBeUndefined();
-                done();
             });
     });
 });
@@ -195,9 +179,9 @@ describe('Windows 8.1 deployment interacts with the file system as expected.', f
         }
     });
 
-    it('Test #006 : enumerateDevices returns a valid set of objects', function (done) {
+    it('Test #006 : enumerateDevices returns a valid set of objects', function () {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        deploymentTool.enumerateDevices()
+        return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
                 expect(deviceList.length).toBe(12);
                 expect(deviceList[0].name).toBe('Device');
@@ -206,70 +190,46 @@ describe('Windows 8.1 deployment interacts with the file system as expected.', f
                 expect(deviceList[5].name).toBe('Mobile Emulator 10.0.10150.0 1080p 6 inch 2GB');
                 expect(deviceList[5].index).toBe(5);
                 expect(deviceList[5].type).toBe('emulator');
-                done();
-            }).fail(function err (errMsg) {
-                expect(errMsg).toBeUndefined();
-                done();
             });
     });
 
-    it('Test #007 : installAppPackage passes the correct set of parameters', function (done) {
+    it('Test #007 : installAppPackage passes the correct set of parameters', function () {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        deploymentTool.enumerateDevices()
+        return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
                 deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ false);
-                done();
-            }).fail(function err (errMsg) {
-                expect(errMsg).toBeUndefined();
-                done();
             });
     });
 
-    it('Test #008 : installAppPackage passes the correct set of parameters when updating', function (done) {
+    it('Test #008 : installAppPackage passes the correct set of parameters when updating', function () {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        deploymentTool.enumerateDevices()
+        return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
                 deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ true);
-                done();
-            }).fail(function err (errMsg) {
-                expect(errMsg).toBeUndefined();
-                done();
             });
     });
 
-    it('Test #009 : installAppPackage passes the correct set of parameters when launching', function (done) {
+    it('Test #009 : installAppPackage passes the correct set of parameters when launching', function () {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        deploymentTool.enumerateDevices()
+        return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
                 deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ true, /* shouldUpdate */ false);
-                done();
-            }).fail(function err (errMsg) {
-                expect(errMsg).toBeUndefined();
-                done();
             });
     });
 
-    it('Test #010 : installAppPackage passes the correct set of parameters when updating and launching', function (done) {
+    it('Test #010 : installAppPackage passes the correct set of parameters when updating and launching', function () {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        deploymentTool.enumerateDevices()
+        return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
                 deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ true, /* shouldUpdate */ true);
-                done();
-            }).fail(function err (errMsg) {
-                expect(errMsg).toBeUndefined();
-                done();
             });
     });
 
-    it('Test #011 : uninstallAppPackage passes the correct set of parameters', function (done) {
+    it('Test #011 : uninstallAppPackage passes the correct set of parameters', function () {
         var deploymentTool = deployment.getDeploymentTool('8.1');
-        deploymentTool.enumerateDevices()
+        return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
                 deploymentTool.uninstallAppPackage(TEST_APP_PACKAGE_ID, deviceList[5]);
-                done();
-            }).fail(function err (errMsg) {
-                expect(errMsg).toBeUndefined();
-                done();
             });
     });
 });

--- a/spec/unit/deployment.spec.js
+++ b/spec/unit/deployment.spec.js
@@ -113,7 +113,7 @@ describe('Windows 10 deployment interacts with the file system as expected.', fu
         var deploymentTool = deployment.getDeploymentTool('10.0');
         return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
-                deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ false);
+                return deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ false);
             });
     });
 
@@ -121,7 +121,7 @@ describe('Windows 10 deployment interacts with the file system as expected.', fu
         var deploymentTool = deployment.getDeploymentTool('10.0');
         return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
-                deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ true);
+                return deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ true);
             });
     });
 
@@ -197,7 +197,7 @@ describe('Windows 8.1 deployment interacts with the file system as expected.', f
         var deploymentTool = deployment.getDeploymentTool('8.1');
         return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
-                deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ false);
+                return deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ false);
             });
     });
 
@@ -205,7 +205,7 @@ describe('Windows 8.1 deployment interacts with the file system as expected.', f
         var deploymentTool = deployment.getDeploymentTool('8.1');
         return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
-                deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ true);
+                return deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ false, /* shouldUpdate */ true);
             });
     });
 
@@ -213,7 +213,7 @@ describe('Windows 8.1 deployment interacts with the file system as expected.', f
         var deploymentTool = deployment.getDeploymentTool('8.1');
         return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
-                deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ true, /* shouldUpdate */ false);
+                return deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ true, /* shouldUpdate */ false);
             });
     });
 
@@ -221,7 +221,7 @@ describe('Windows 8.1 deployment interacts with the file system as expected.', f
         var deploymentTool = deployment.getDeploymentTool('8.1');
         return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
-                deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ true, /* shouldUpdate */ true);
+                return deploymentTool.installAppPackage(TEST_APP_PACKAGE_NAME, deviceList[0], /* shouldLaunch */ true, /* shouldUpdate */ true);
             });
     });
 
@@ -229,7 +229,7 @@ describe('Windows 8.1 deployment interacts with the file system as expected.', f
         var deploymentTool = deployment.getDeploymentTool('8.1');
         return deploymentTool.enumerateDevices()
             .then(function (deviceList) {
-                deploymentTool.uninstallAppPackage(TEST_APP_PACKAGE_ID, deviceList[5]);
+                return deploymentTool.uninstallAppPackage(TEST_APP_PACKAGE_ID, deviceList[5]);
             });
     });
 });

--- a/spec/unit/package.spec.js
+++ b/spec/unit/package.spec.js
@@ -43,72 +43,48 @@ describe('getPackage method', function () {
         shell.cp('-R', testPkgPath, pkgRoot);
     });
 
-    it('spec.1 should find windows anycpu debug package', function (done) {
-        var rejected = jasmine.createSpy();
-
-        pkg.getPackage('windows', 'debug', 'anycpu')
+    it('spec.1 should find windows anycpu debug package', function () {
+        return pkg.getPackage('windows', 'debug', 'anycpu')
             .then(function (pkgInfo) {
                 expect(pkgInfo.type).toBe('windows');
                 expect(pkgInfo.buildtype).toBe('debug');
                 expect(pkgInfo.arch).toBe('anycpu');
                 expect(pkgInfo.script).toBeDefined();
-            }, function (err) {
-                console.error(err);
-                rejected();
-            })
-            .finally(function () {
-                expect(rejected).not.toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec.2 should find windows phone anycpu debug package', function (done) {
-        var rejected = jasmine.createSpy();
-
-        pkg.getPackage('phone', 'debug', 'anycpu')
+    it('spec.2 should find windows phone anycpu debug package', function () {
+        return pkg.getPackage('phone', 'debug', 'anycpu')
             .then(function (pkgInfo) {
                 expect(pkgInfo.type).toBe('phone');
                 expect(pkgInfo.buildtype).toBe('debug');
                 expect(pkgInfo.arch).toBe('anycpu');
                 expect(pkgInfo.script).toBeDefined();
-            }, rejected)
-            .finally(function () {
-                expect(rejected).not.toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec.3 should not find windows 10 anycpu debug package', function (done) {
-        var resolved = jasmine.createSpy();
-
-        pkg.getPackage('windows10', 'debug', 'anycpu')
-            .then(resolved)
-            .finally(function () {
-                expect(resolved).not.toHaveBeenCalled();
-                done();
-            });
+    it('spec.3 should not find windows 10 anycpu debug package', function () {
+        return pkg.getPackage('windows10', 'debug', 'anycpu')
+            .then(
+                () => fail('Expected promise to be rejected'),
+                () => expect().nothing()
+            );
     });
 
-    it('spec.4 should not find windows anycpu release package', function (done) {
-        var resolved = jasmine.createSpy();
-
-        pkg.getPackage('windows', 'release', 'anycpu')
-            .then(resolved)
-            .finally(function () {
-                expect(resolved).not.toHaveBeenCalled();
-                done();
-            });
+    it('spec.4 should not find windows anycpu release package', function () {
+        return pkg.getPackage('windows', 'release', 'anycpu')
+            .then(
+                () => fail('Expected promise to be rejected'),
+                () => expect().nothing()
+            );
     });
 
-    it('spec.5 should not find windows x86 debug package', function (done) {
-        var resolved = jasmine.createSpy();
-
-        pkg.getPackage('windows', 'debug', 'x86')
-            .then(resolved)
-            .finally(function () {
-                expect(resolved).not.toHaveBeenCalled();
-                done();
-            });
+    it('spec.5 should not find windows x86 debug package', function () {
+        return pkg.getPackage('windows', 'debug', 'x86')
+            .then(
+                () => fail('Expected promise to be rejected'),
+                () => expect().nothing()
+            );
     });
 
     it('end', function () {

--- a/spec/unit/package.spec.js
+++ b/spec/unit/package.spec.js
@@ -19,7 +19,6 @@
 var path = require('path');
 var rewire = require('rewire');
 var shell = require('shelljs');
-var Q = require('q');
 var platformRoot = '../../template';
 var pkgRoot = './template/';
 var pkgPath = path.join(pkgRoot, 'AppPackages');
@@ -156,14 +155,7 @@ describe('getPackageFileInfo method', function () {
 });
 
 describe('getAppId method', function () {
-    it('spec.11 should properly get Application Id value from manifest', function (done) {
-        var resolve = jasmine.createSpy();
-
-        Q(pkg.getAppId(pkgRoot))
-            .then(resolve)
-            .finally(function () {
-                expect(resolve).toHaveBeenCalledWith('$guid1$');
-                done();
-            });
+    it('spec.11 should properly get Application Id value from manifest', function () {
+        expect(pkg.getAppId(pkgRoot)).toBe('$guid1$');
     });
 });

--- a/spec/unit/package.spec.js
+++ b/spec/unit/package.spec.js
@@ -156,19 +156,6 @@ describe('getPackageFileInfo method', function () {
 });
 
 describe('getAppId method', function () {
-    it('spec.10 should properly get phoneProductId value from manifest', function (done) {
-        var resolve = jasmine.createSpy();
-
-        Q(pkg.getAppId(pkgRoot))
-            .then(resolve)
-            .finally(function () {
-                expect(resolve).toHaveBeenCalledWith('$guid1$');
-                done();
-            });
-    });
-});
-
-describe('getPackageName method', function () {
     it('spec.11 should properly get Application Id value from manifest', function (done) {
         var resolve = jasmine.createSpy();
 

--- a/spec/unit/run.spec.js
+++ b/spec/unit/run.spec.js
@@ -68,7 +68,7 @@ describe('run method', function () {
         run.__set__('ranWithElevatedPermissions', ranWithElevatedPermissionsOriginal);
     });
 
-    it('spec.1 should not run if not launched from project directory', function (done) {
+    it('spec.1 should not run if not launched from project directory', function () {
         var buildRun = jasmine.createSpy();
 
         run.__set__('utils.isCordovaProject', isCordovaProjectFalse);
@@ -77,14 +77,13 @@ describe('run method', function () {
             return Q.reject(); // rejecting to break run chain
         });
 
-        run.run([ 'node', buildPath ])
-            .finally(function () {
-                expect(buildRun).not.toHaveBeenCalled();
-                done();
-            });
+        return run.run([ 'node', buildPath ]).then(
+            () => fail('Expected promise to be rejected'),
+            () => expect(buildRun).not.toHaveBeenCalled()
+        );
     });
 
-    it('spec.2 should not run if both debug and release args are specified', function (done) {
+    it('spec.2 should not run if both debug and release args are specified', function () {
         var buildRun = jasmine.createSpy();
 
         run.__set__('utils.isCordovaProject', isCordovaProjectTrue);
@@ -93,14 +92,13 @@ describe('run method', function () {
             return Q.reject(); // rejecting to break run chain
         });
 
-        run.run({ release: true, debug: true })
-            .finally(function () {
-                expect(buildRun).not.toHaveBeenCalled();
-                done();
-            });
+        return run.run({ release: true, debug: true }).then(
+            () => fail('Expected promise to be rejected'),
+            () => expect(buildRun).not.toHaveBeenCalled()
+        );
     });
 
-    it('spec.3 should not run if device and emulator args are combined', function (done) {
+    it('spec.3 should not run if device and emulator args are combined', function () {
         var buildRun = jasmine.createSpy();
 
         run.__set__('utils.isCordovaProject', isCordovaProjectTrue);
@@ -109,14 +107,13 @@ describe('run method', function () {
             return Q.reject(); // rejecting to break run chain
         });
 
-        run.run({ device: true, emulator: true })
-            .finally(function () {
-                expect(buildRun).not.toHaveBeenCalled();
-                done();
-            });
+        return run.run({ device: true, emulator: true }).then(
+            () => fail('Expected promise to be rejected'),
+            () => expect(buildRun).not.toHaveBeenCalled()
+        );
     });
 
-    it('spec.4 should not run if device and target args are combined', function (done) {
+    it('spec.4 should not run if device and target args are combined', function () {
         var buildRun = jasmine.createSpy();
 
         run.__set__('utils.isCordovaProject', isCordovaProjectTrue);
@@ -125,18 +122,16 @@ describe('run method', function () {
             return Q.reject(); // rejecting to break run chain
         });
 
-        run.run({ device: true, target: 'sometargethere' })
-            .finally(function () {
-                expect(buildRun).not.toHaveBeenCalled();
-                done();
-            });
+        return run.run({ device: true, target: 'sometargethere' }).then(
+            () => fail('Expected promise to be rejected'),
+            () => expect(buildRun).not.toHaveBeenCalled()
+        );
     });
 
-    it('spec.5 should build and deploy on phone if --phone arg specified', function (done) {
+    it('spec.5 should build and deploy on phone if --phone arg specified', function () {
         var build = jasmine.createSpy();
         var deployToPhone = jasmine.createSpy();
         var deployToDesktop = jasmine.createSpy();
-        var failed = jasmine.createSpy();
 
         run.__set__('utils.isCordovaProject', isCordovaProjectTrue);
         run.__set__('build.run', function () {
@@ -167,18 +162,15 @@ describe('run method', function () {
             return Q();
         });
 
-        run.run([ 'node', buildPath, '--phone', '--break' ])
-            .catch(failed)
-            .finally(function () {
-                expect(failed).not.toHaveBeenCalled();
+        return run.run([ 'node', buildPath, '--phone', '--break' ])
+            .then(() => {
                 expect(build).toHaveBeenCalled();
                 expect(deployToPhone).toHaveBeenCalled();
                 expect(deployToDesktop).not.toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec.6 should build and deploy on desktop if --phone arg is not specified', function (done) {
+    it('spec.6 should build and deploy on desktop if --phone arg is not specified', function () {
         var build = jasmine.createSpy();
         var deployToPhone = jasmine.createSpy();
         var deployToDesktop = jasmine.createSpy();
@@ -212,16 +204,15 @@ describe('run method', function () {
             return Q();
         });
 
-        run.run([ 'node', buildPath ])
+        return run.run([ 'node', buildPath ])
             .finally(function () {
                 expect(build).toHaveBeenCalled();
                 expect(deployToDesktop).toHaveBeenCalled();
                 expect(deployToPhone).not.toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec. 7 should not call build if --nobuild specified', function (done) {
+    it('spec. 7 should not call build if --nobuild specified', function () {
         var build = jasmine.createSpy();
         var deployToDesktop = jasmine.createSpy();
 
@@ -241,15 +232,14 @@ describe('run method', function () {
             return Q();
         });
 
-        run.run({ nobuild: true })
+        return run.run({ nobuild: true })
             .finally(function () {
                 expect(deployToDesktop).toHaveBeenCalled();
                 expect(build).not.toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec.8 should accept --archs parameter either as cli or as platform arg', function (done) {
+    it('spec.8 should accept --archs parameter either as cli or as platform arg', function () {
 
         spyOn(utils, 'isCordovaProject').and.returnValue(true);
         spyOn(packages, 'getPackage').and.returnValue(Q({ arch: 'arm' }));
@@ -258,12 +248,7 @@ describe('run method', function () {
         var anyString = jasmine.any(String);
         var expectedDeployOptions = jasmine.objectContaining({ arch: 'arm' });
 
-        var fail = jasmine.createSpy('fail')
-            .and.callFake(function (err) {
-                console.error(err);
-            });
-
-        run.run({ nobuild: true, argv: ['--archs=arm'] })
+        return run.run({ nobuild: true, argv: ['--archs=arm'] })
             .then(function () {
                 expect(packages.getPackage).toHaveBeenCalledWith(anyString, anyString, 'arm');
                 expect(packages.deployToDesktop).toHaveBeenCalledWith(expectedDeployOptions, anyString, anyString);
@@ -274,15 +259,10 @@ describe('run method', function () {
             .then(function () {
                 expect(packages.getPackage).toHaveBeenCalledWith(anyString, anyString, 'arm');
                 expect(packages.deployToDesktop).toHaveBeenCalledWith(expectedDeployOptions, anyString, anyString);
-            })
-            .catch(fail)
-            .finally(function () {
-                expect(fail).not.toHaveBeenCalled();
-                done();
             });
     });
 
-    it('spec.9 should fall back to anycpu if --archs parameter is not specified', function (done) {
+    it('spec.9 should fall back to anycpu if --archs parameter is not specified', function () {
 
         spyOn(utils, 'isCordovaProject').and.returnValue(true);
         spyOn(packages, 'getPackage').and.returnValue(Q({ arch: 'anycpu' }));
@@ -291,17 +271,10 @@ describe('run method', function () {
         var anyString = jasmine.any(String);
         var expectedDeployOptions = jasmine.objectContaining({ arch: 'anycpu' });
 
-        var fail = jasmine.createSpy('fail');
-
-        run.run({ nobuild: true })
+        return run.run({ nobuild: true })
             .then(function () {
                 expect(packages.getPackage).toHaveBeenCalledWith(anyString, anyString, 'anycpu');
                 expect(packages.deployToDesktop).toHaveBeenCalledWith(expectedDeployOptions, anyString, anyString);
-            })
-            .catch(fail)
-            .finally(function () {
-                expect(fail).not.toHaveBeenCalled();
-                done();
             });
     });
 });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Part of apache/cordova#169


### Description
<!-- Describe your changes in detail -->
- Merge duplicated tests in package.spec into one
- Don't use `done` for synchronous tests
- Let Jasmine handle promises in tests
- fix: return unhandled promises in spec
