### PR TITLE
breaking: bump node support >=10.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ git:
   depth: 10
 
 node_js:
-  - 6
-  - 8
   - 10
   - 12
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,18 +21,18 @@
 
 environment:
   matrix:
-    - nodejs_version: "6"
+    - nodejs_version: "10"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    - nodejs_version: "6"
+    - nodejs_version: "10"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       MSBUILDDIR: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\"
 
-    - nodejs_version: "6"
+    - nodejs_version: "10"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       MSBUILDDIR: "C:\\Program Files (x86)\\MSBuild\\14.0\\bin\\"
 
-    - nodejs_version: "6"
+    - nodejs_version: "10"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rewire": "^4.0.1"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Motivation and Context

Bump node engine requirement to >=10.0.0