### PR TITLE
chore: upgrade & set fs-extra as release dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "cordova-common": "^3.2.0",
     "elementtree": "^0.1.7",
+    "fs-extra": "^9.0.0",
     "node-uuid": "^1.4.8",
     "nopt": "^4.0.1",
     "q": "^1.5.1",
@@ -41,7 +42,6 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "fs-extra": "^8.1.0",
     "jasmine": "3.1.0",
     "nyc": "^14.1.1",
     "rewire": "^4.0.1"


### PR DESCRIPTION
### Motivation and Context

- Upgrade `fs-extra` dependency to use latest
- `fs-extra` should be a release dependency, not a dev dependency

Requires: #376

### Testing

- `npm run cover`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
