### PR TITLE
breaking: bump non-cordova release dependencies w/ fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "elementtree": "^0.1.7",
     "fs-extra": "^9.0.0",
     "node-uuid": "^1.4.8",
-    "nopt": "^4.0.1",
+    "nopt": "^4.0.3",
     "q": "^1.5.1",
-    "semver": "^5.5.0",
-    "shelljs": "^0.5.3",
+    "semver": "^7.3.2",
+    "shelljs": "^0.8.4",
     "winjs": "^4.4.3"
   },
   "devDependencies": {

--- a/spec/unit/JsprojManager.spec.js
+++ b/spec/unit/JsprojManager.spec.js
@@ -55,9 +55,11 @@ describe('JsprojManager', function () {
     });
 
     it('should throw if project is not a windows project', function () {
+        shell.config.silent = true; // disabeling print out temporarily
         shell.ls.and.callThrough();
         expect(function () {
             JsprojManager.getProject(INVALID_PROJECT_PATH);
+            shell.config.silent = false;
         }).toThrow();
     });
 

--- a/spec/unit/pluginHandler/common.spec.js
+++ b/spec/unit/pluginHandler/common.spec.js
@@ -19,7 +19,7 @@
 var rewire = require('rewire');
 var common = rewire('../../../template/cordova/lib/PluginHandler');
 var path = require('path');
-var fs = require('fs');
+var fs = require('fs-extra');
 var os = require('os');
 var shell = require('shelljs');
 
@@ -123,14 +123,13 @@ describe('common platform handler', function () {
     });
 
     describe('deleteJava', function () {
-        it('Test #008 : should call fs.unlinkSync on the provided paths', function () {
+        it('Test #008 : source file should have been removed.', function () {
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 
-            var s = spyOn(fs, 'unlinkSync').and.callThrough();
+            expect(fs.existsSync(java_file)).toBe(true);
             removeFileAndParents(project_dir, java_file);
-            expect(s).toHaveBeenCalled();
-            expect(s).toHaveBeenCalledWith(path.resolve(project_dir, java_file));
+            expect(fs.existsSync(java_file)).toBe(false);
 
             shell.rm('-rf', java_dir);
         });

--- a/spec/unit/pluginHandler/windows.spec.js
+++ b/spec/unit/pluginHandler/windows.spec.js
@@ -17,7 +17,7 @@
  under the License.
  */
 
-var fs = require('fs');
+var fs = require('fs-extra');
 var os = require('os');
 var et = require('elementtree');
 var path = require('path');
@@ -931,7 +931,7 @@ describe('windows project handler', function () {
                 wwwDest = path.resolve(dummyProject.www, 'plugins', dummyPluginInfo.id, jsModule.src);
                 platformWwwDest = path.resolve(dummyProject.platformWww, 'plugins', dummyPluginInfo.id, jsModule.src);
 
-                spyOn(shell, 'rm');
+                spyOn(fs, 'removeSync');
 
                 var existsSyncOrig = fs.existsSync;
                 spyOn(fs, 'existsSync').and.callFake(function (file) {
@@ -942,14 +942,14 @@ describe('windows project handler', function () {
 
             it('Test #047 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
                 uninstall(jsModule, dummyPluginInfo, dummyProject, { usePlatformWww: true });
-                expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), wwwDest);
-                expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), platformWwwDest);
+                expect(fs.removeSync).toHaveBeenCalledWith(wwwDest);
+                expect(fs.removeSync).toHaveBeenCalledWith(platformWwwDest);
             });
 
             it('Test #048 : should put module to www only when options.usePlatformWww flag is not specified', function () {
                 uninstall(jsModule, dummyPluginInfo, dummyProject);
-                expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), wwwDest);
-                expect(shell.rm).not.toHaveBeenCalledWith(jasmine.any(String), platformWwwDest);
+                expect(fs.removeSync).toHaveBeenCalledWith(wwwDest);
+                expect(fs.removeSync).not.toHaveBeenCalledWith(platformWwwDest);
             });
         });
 

--- a/template/cordova/lib/PluginHandler.js
+++ b/template/cordova/lib/PluginHandler.js
@@ -17,7 +17,7 @@
  *
  */
 
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 var shell = require('shelljs');
 var events = require('cordova-common').events;
@@ -255,7 +255,7 @@ function removeFileAndParents (baseDir, destFile, stopper) {
     var file = path.resolve(baseDir, destFile);
     if (!fs.existsSync(file)) return;
 
-    shell.rm('-rf', file);
+    fs.removeSync(file);
 
     // check if directory is empty
     var curDir = path.dirname(file);


### PR DESCRIPTION
### Motivation and Context

Bump non-Cordova dependencies to latest release.

* nopt@^4.0.3
* semver@^7.3.2
* shelljs@^0.8.4

### Testing

- `npm run cover`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
