### PR TITLE
ci: fix GH Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@
 # under the License.
 
 name: Node CI
-
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
-        os: [windows-latest]
+        node-version: [14.x]
+        os: [windows-2016]
 
     steps:
       - uses: actions/checkout@v2
@@ -37,11 +37,15 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+          
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.3
 
       - name: Environment Information
         run: |
           node --version
           npm --version
+          msbuild -version
 
       - name: npm install and test
         run: |


### PR DESCRIPTION
This is a WIP PR to fix our GH Actions CI.

Our JS unit tests are platform independent (see existing Travis CI job which runs them on Linux) but our E2E tests require WIndows with VS2017 to run. The only way I could find to get that in GH Actions, is to use the `windows-2016` image. Unfortunately, that image is deprecated and scheduled to be removed 05/2022. I encountered a few issues asking for the inclusion for VS2017 in the newer images, but they had all been closed without a fix.

Given that this platform is very inactive, I would rather not spend any more time getting GH Actions running. Instead I suggest we remove it for now, so that we do not have a red herring in our CI jobs.

I'll leave this draft PR as a starting point, should anyone decide to make it work. FYI: in the current state there are some failures even though we have VS2017 available. I haven't looked into them for above reasons and because I lack experience with the platform.